### PR TITLE
export error domain for libhinawa

### DIFF
--- a/doc/reference/hinawa-docs.xml
+++ b/doc/reference/hinawa-docs.xml
@@ -44,6 +44,11 @@
         <xi:include href="xml/hinawa_enum_types.xml"/>
     </chapter>
 
+    <chapter id="hinawa-error">
+        <title>Hinawa errors</title>
+        <xi:include href="xml/hinawa_error.xml"/>
+    </chapter>
+
     <chapter id="hinawa-fw">
         <title>Hinawa objects for Linux FireWire subsystem.</title>
         <para>This library gives 5 objects for abstractions of some

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -7,6 +7,7 @@
 
 #include <fw_node.h>
 #include <fw_resp.h>
+#include <hinawa_error.h>
 #include <hinawa_enums.h>
 
 G_BEGIN_DECLS

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -5,6 +5,8 @@
 #include <glib.h>
 #include <glib-object.h>
 
+#include <hinawa_error.h>
+
 G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_NODE	(hinawa_fw_node_get_type())

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -6,6 +6,7 @@
 #include <glib-object.h>
 
 #include <fw_node.h>
+#include <hinawa_error.h>
 #include <hinawa_enums.h>
 
 G_BEGIN_DECLS

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -19,12 +19,6 @@
  * utilize ioctl(2) with subsystem specific request commands.
  */
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaFwResp", hinawa_fw_resp)
-#define raise(exception, errno)						\
-	g_set_error(exception, hinawa_fw_resp_quark(), errno,		\
-		    "%d: %s", __LINE__, strerror(errno))
-
 struct _HinawaFwRespPrivate {
 	HinawaFwNode *node;
 
@@ -160,7 +154,7 @@ void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
 	priv = hinawa_fw_resp_get_instance_private(self);
 
 	if (priv->node != NULL) {
-		raise(exception, EINVAL);
+		generate_error(exception, EINVAL);
 		return;
 	}
 
@@ -171,21 +165,21 @@ void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
 
 	hinawa_fw_node_ioctl(node, FW_CDEV_IOC_ALLOCATE, &allocate, &err);
 	if (err < 0) {
-		raise(exception, err);
+		generate_error(exception, -err);
 		return;
 	}
 	priv->node = g_object_ref(node);
 
 	priv->req_frame = g_malloc(allocate.length);
 	if (!priv->req_frame) {
-		raise(exception, ENOMEM);
+		generate_error(exception, ENOMEM);
 		hinawa_fw_resp_release(self);
 		return;
 	}
 
 	priv->resp_frame = g_malloc0(allocate.length);
 	if (!priv->resp_frame) {
-		raise(exception, ENOMEM);
+		generate_error(exception, ENOMEM);
 		hinawa_fw_resp_release(self);
 		return;
 	}

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -6,6 +6,7 @@
 #include <glib-object.h>
 
 #include <fw_node.h>
+#include <hinawa_error.h>
 #include <hinawa_enums.h>
 
 G_BEGIN_DECLS

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -8,7 +8,6 @@ HINAWA_0_6_0 {
 
     "hinawa_snd_unit_get_type";
     "hinawa_snd_unit_open";
-    "hinawa_snd_unit_quark";
     "hinawa_snd_unit_lock";
     "hinawa_snd_unit_unlock";
 

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -3,7 +3,6 @@ HINAWA_0_6_0 {
     "hinawa_fw_req_get_type";
 
     "hinawa_fw_resp_get_type";
-    "hinawa_fw_resp_quark";
 
     "hinawa_fw_fcp_get_type";
     "hinawa_fw_fcp_quark";

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -16,7 +16,6 @@ HINAWA_0_6_0 {
 
     "hinawa_snd_efw_get_type";
     "hinawa_snd_efw_open";
-    "hinawa_snd_efw_quark";
   local:
     *;
 };

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -1,7 +1,6 @@
 HINAWA_0_6_0 {
   global:
     "hinawa_fw_req_get_type";
-    "hinawa_fw_req_quark";
 
     "hinawa_fw_resp_get_type";
     "hinawa_fw_resp_quark";

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -30,7 +30,6 @@ HINAWA_0_8_0 {
   global:
     "hinawa_snd_motu_get_type";
     "hinawa_snd_motu_open";
-    "hinawa_snd_motu_quark";
 } HINAWA_0_7_0;
 
 HINAWA_1_0_0 {

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -5,7 +5,6 @@ HINAWA_0_6_0 {
     "hinawa_fw_resp_get_type";
 
     "hinawa_fw_fcp_get_type";
-    "hinawa_fw_fcp_quark";
 
     "hinawa_snd_unit_get_type";
     "hinawa_snd_unit_open";

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -13,7 +13,6 @@ HINAWA_0_6_0 {
 
     "hinawa_snd_dice_get_type";
     "hinawa_snd_dice_open";
-    "hinawa_snd_dice_quark";
 
     "hinawa_snd_efw_get_type";
     "hinawa_snd_efw_open";

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -24,7 +24,6 @@ HINAWA_0_7_0 {
   global:
     "hinawa_snd_dg00x_get_type";
     "hinawa_snd_dg00x_open";
-    "hinawa_snd_dg00x_quark";
 } HINAWA_0_6_0;
 
 HINAWA_0_8_0 {

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -72,7 +72,6 @@ HINAWA_1_3_0 {
 HINAWA_1_4_0 {
     "hinawa_fw_node_get_type";
     "hinawa_fw_node_new";
-    "hinawa_fw_node_quark";
     "hinawa_fw_node_open";
     "hinawa_fw_node_create_source";
 

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -100,3 +100,7 @@ HINAWA_2_0_0 {
 
     "hinawa_snd_unit_get_node";
 } HINAWA_1_4_0;
+
+HINAWA_2_1_0 {
+    "hinawa_error_quark";
+} HINAWA_2_0_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -44,7 +44,6 @@ HINAWA_1_0_0 {
 HINAWA_1_1_0 {
     "hinawa_snd_tscm_get_type";
     "hinawa_snd_tscm_open";
-    "hinawa_snd_tscm_quark";
     "hinawa_sigs_marshal_VOID__UINT_UINT_UINT";
     "hinawa_snd_tscm_get_state";
 } HINAWA_1_0_0;

--- a/src/hinawa_error.c
+++ b/src/hinawa_error.c
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#include "hinawa_error.h"
+
+/**
+ * SECTION:hinawa_error
+ * @short_description: Represent domain for errors in libhinawa.
+ * @include: hinawa_error.h
+ *
+ * GError with the domain has error code from errno.h for Linux system. No GLib
+ * enumerations for the code is provided currently.
+ */
+
+/**
+ * hinawa_error_quark:
+ *
+ * Retrieve GQuark as identifier for domain of error in libhinawa.
+ *
+ * Returns: A #GQuark;
+ */
+G_DEFINE_QUARK(hinawa-error-quark, hinawa_error)

--- a/src/hinawa_error.h
+++ b/src/hinawa_error.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+#ifndef __ALSA_HINAWA_ERROR_H__
+#define __ALSA_HINAWA_ERROR_H__
+
+#include <glib.h>
+
+GQuark hinawa_error_quark();
+
+#define HINAWA_ERROR	hinawa_error_quark()
+
+#endif

--- a/src/internal.h
+++ b/src/internal.h
@@ -9,6 +9,7 @@
 
 #include <sound/firewire.h>
 
+#include "hinawa_error.h"
 #include "fw_node.h"
 #include "fw_resp.h"
 #include "fw_req.h"
@@ -18,6 +19,10 @@
 #include "snd_dg00x.h"
 #include "snd_motu.h"
 #include "snd_tscm.h"
+
+#define generate_error(exception, errno)			\
+	g_set_error(exception, HINAWA_ERROR, errno,		\
+		    "%s:%d: %s", __FILE__, __LINE__, strerror(errno))
 
 void hinawa_fw_node_ioctl(HinawaFwNode *self, unsigned long req, void *args,
 			  int *err);

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,7 @@ sources = [
   'snd_dg00x.c',
   'snd_motu.c',
   'snd_tscm.c',
+  'hinawa_error.c',
 ]
 
 headers = [
@@ -35,6 +36,7 @@ headers = [
   'snd_dg00x.h',
   'snd_motu.h',
   'snd_tscm.h',
+  'hinawa_error.h',
 ]
 
 privates = [

--- a/src/snd_dg00x.c
+++ b/src/snd_dg00x.c
@@ -16,12 +16,6 @@
 
 G_DEFINE_TYPE(HinawaSndDg00x, hinawa_snd_dg00x, HINAWA_TYPE_SND_UNIT)
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaSndDg00x", hinawa_snd_dg00x)
-#define raise(exception, errno)						\
-	g_set_error(exception, hinawa_snd_dg00x_quark(), errno,		\
-		    "%d: %s", __LINE__, strerror(errno))
-
 /* This object has one signal. */
 enum dg00x_sig_type {
 	DG00X_SIG_TYPE_MESSAGE,
@@ -87,7 +81,7 @@ void hinawa_snd_dg00x_open(HinawaSndDg00x *self, gchar *path, GError **exception
 
 	g_object_get(G_OBJECT(self), "type", &type, NULL);
 	if (type != SNDRV_FIREWIRE_TYPE_DIGI00X) {
-		raise(exception, EINVAL);
+		generate_error(exception, EINVAL);
 		return;
 	}
 }

--- a/src/snd_dg00x.h
+++ b/src/snd_dg00x.h
@@ -6,6 +6,7 @@
 #include <glib-object.h>
 
 #include <snd_unit.h>
+#include <hinawa_error.h>
 
 G_BEGIN_DECLS
 

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -14,12 +14,6 @@
  * received. This inherits #HinawaSndUnit.
  */
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaSndDice", hinawa_snd_dice)
-#define raise(exception, errno)						\
-	g_set_error(exception, hinawa_snd_dice_quark(), errno,		\
-		    "%d: %s", __LINE__, strerror(errno))
-
 struct notification_waiter {
 	guint32 bit_flag;
 	GCond cond;
@@ -115,7 +109,7 @@ void hinawa_snd_dice_open(HinawaSndDice *self, gchar *path, GError **exception)
 
 	g_object_get(G_OBJECT(self), "type", &type, NULL);
 	if (type != SNDRV_FIREWIRE_TYPE_DICE) {
-		raise(exception, EINVAL);
+		generate_error(exception, EINVAL);
 		return;
 	}
 
@@ -166,7 +160,7 @@ void hinawa_snd_dice_transaction(HinawaSndDice *self, guint64 addr,
 	length = frame_count * sizeof(*frame);
 	req_frame = g_malloc0(length);
 	if (req_frame == NULL) {
-		raise(exception, ENOMEM);
+		generate_error(exception, ENOMEM);
 		return;
 	}
 	for (i = 0; i < frame_count; ++i) {
@@ -199,7 +193,7 @@ void hinawa_snd_dice_transaction(HinawaSndDice *self, guint64 addr,
 			break;
 	}
 	if (!waiter.awakened)
-		raise(exception, ETIMEDOUT);
+		generate_error(exception, ETIMEDOUT);
 end:
 	priv->waiters = g_list_remove(priv->waiters, (gpointer *)&waiter);
 

--- a/src/snd_dice.h
+++ b/src/snd_dice.h
@@ -6,6 +6,7 @@
 #include <glib-object.h>
 
 #include <snd_unit.h>
+#include <hinawa_error.h>
 
 G_BEGIN_DECLS
 

--- a/src/snd_efw.h
+++ b/src/snd_efw.h
@@ -6,6 +6,7 @@
 #include <glib-object.h>
 
 #include <snd_unit.h>
+#include <hinawa_error.h>
 
 G_BEGIN_DECLS
 

--- a/src/snd_motu.c
+++ b/src/snd_motu.c
@@ -14,12 +14,6 @@
  * Mark of the Unicorn (MOTU). This inherits #HinawaSndUnit.
  */
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaSndMotu", hinawa_snd_motu)
-#define raise(exception, errno)						\
-	g_set_error(exception, hinawa_snd_motu_quark(), errno,		\
-		    "%d: %s", __LINE__, strerror(errno))
-
 struct _HinawaSndMotuPrivate {
 	struct snd_firewire_motu_status *status;
 };
@@ -90,7 +84,7 @@ void hinawa_snd_motu_open(HinawaSndMotu *self, gchar *path, GError **exception)
 
 	g_object_get(G_OBJECT(self), "type", &type, NULL);
 	if (type != SNDRV_FIREWIRE_TYPE_MOTU) {
-		raise(exception, EINVAL);
+		generate_error(exception, EINVAL);
 		return;
 	}
 }

--- a/src/snd_motu.h
+++ b/src/snd_motu.h
@@ -6,6 +6,7 @@
 #include <glib-object.h>
 
 #include <snd_unit.h>
+#include <hinawa_error.h>
 
 G_BEGIN_DECLS
 

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -16,12 +16,6 @@
  * inherits #HinawaSndUnit.
  */
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaSndTscm", hinawa_snd_tscm)
-#define raise(exception, errno)					\
-	g_set_error(exception, hinawa_snd_tscm_quark(), errno,	\
-		    "%d: %s", __LINE__, strerror(errno))
-
 struct _HinawaSndTscmPrivate {
 	struct snd_firewire_tascam_state image;
 	guint32 state[SNDRV_FIREWIRE_TASCAM_STATE_COUNT];
@@ -96,7 +90,7 @@ void hinawa_snd_tscm_open(HinawaSndTscm *self, gchar *path, GError **exception)
 
 	g_object_get(G_OBJECT(self), "type", &type, NULL);
 	if (type != SNDRV_FIREWIRE_TYPE_TASCAM) {
-		raise(exception, EINVAL);
+		generate_error(exception, EINVAL);
 		return;
 	}
 }

--- a/src/snd_tscm.h
+++ b/src/snd_tscm.h
@@ -6,6 +6,7 @@
 #include <glib-object.h>
 
 #include <snd_unit.h>
+#include <hinawa_error.h>
 
 G_BEGIN_DECLS
 


### PR DESCRIPTION
This patchset is fix for #56 .

The libhinawa has multiple instances of GQuark for domain of errors in
each object. Although symbols for functions to retrieve the GQuark
instances are globally exported, no API is provided for applications.
Therefore it's possible to add changes relevant to the instances without
any regressions for applications.

This patchset unifies the instances into single, therefore one function
is added to retrieve the instance, hinawa_error_quark(). The other instances
are useless and obsoleted.

Instances of GError with the instance as domain have error code from
errno.h in Linux system. Although this is against GLib recommendation,
it's hard to cover all error path in kernel drivers.