### PR TITLE
enhancement for error reporting

### DIFF
--- a/samples/gtk3.py
+++ b/samples/gtk3.py
@@ -106,7 +106,7 @@ print(' Config ROM:')
 config_rom = node.get_config_rom()
 quads = unpack('>{}I'.format(len(config_rom) // 4), config_rom)
 for i, q in enumerate(quads):
-    print('  0xfffff000{:04x}: {:08x}'.format(i * 4, q))
+    print('  0xfffff00004{:02x}: {:08x}'.format(i * 4, q))
 
 # create firewire responder
 resp = Hinawa.FwResp()

--- a/samples/gtk3.py
+++ b/samples/gtk3.py
@@ -23,6 +23,7 @@ snd_specific_types = {
     Hinawa.SndUnitType.FIREWORKS:   Hinawa.SndEfw,
     Hinawa.SndUnitType.DIGI00X:     Hinawa.SndDg00x,
     Hinawa.SndUnitType.MOTU:        Hinawa.SndMotu,
+    Hinawa.SndUnitType.TASCAM:      Hinawa.SndTscm,
 }
 for p in Path('/dev/snd/').glob('hw*'):
     fullpath = str(p)
@@ -193,6 +194,12 @@ def handle_motu_notification(self, message):
     print("Motu Notification: {0:08x}".format(message))
 if unit.get_property('type') is Hinawa.SndUnitType.MOTU:
     unit.connect('notified', handle_motu_notification)
+
+# Tascam control
+def handle_tscm_control(self, index, before, after):
+    print('control:{}: {:08x}'.format(index, before ^ after))
+if unit.get_property('type') is Hinawa.SndUnitType.TASCAM:
+    unit.connect('control', handle_tscm_control)
 
 # GUI
 class Sample(Gtk.Window):

--- a/samples/qt5.py
+++ b/samples/qt5.py
@@ -24,6 +24,7 @@ snd_specific_types = {
     Hinawa.SndUnitType.FIREWORKS:   Hinawa.SndEfw,
     Hinawa.SndUnitType.DIGI00X:     Hinawa.SndDg00x,
     Hinawa.SndUnitType.MOTU:        Hinawa.SndMotu,
+    Hinawa.SndUnitType.TASCAM:      Hinawa.SndTscm,
 }
 for p in Path('/dev/snd/').glob('hw*'):
     fullpath = str(p)
@@ -194,6 +195,12 @@ def handle_motu_notification(self, message):
     print("Motu Notification: {0:08x}".format(message))
 if unit.get_property('type') is Hinawa.SndUnitType.MOTU:
     unit.connect('notified', handle_motu_notification)
+
+# Tascam control
+def handle_tscm_control(self, index, before, after):
+    print('control:{}: {:08x}'.format(index, before ^ after))
+if unit.get_property('type') is Hinawa.SndUnitType.TASCAM:
+    unit.connect('control', handle_tscm_control)
 
 # GUI
 class Sample(QWidget):

--- a/samples/qt5.py
+++ b/samples/qt5.py
@@ -107,7 +107,7 @@ print(' Config ROM:')
 config_rom = node.get_config_rom()
 quads = unpack('>{}I'.format(len(config_rom) // 4), config_rom)
 for i, q in enumerate(quads):
-    print('  0xfffff000{:04x}: {:08x}'.format(i * 4, q))
+    print('  0xfffff00004{:02x}: {:08x}'.format(i * 4, q))
 
 # create firewire responder
 resp = Hinawa.FwResp()

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -206,6 +206,8 @@ void hinawa_fw_fcp_transaction(HinawaFwFcp *self,
 	gint64 expiration;
 
 	g_return_if_fail(HINAWA_IS_FW_FCP(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_fw_fcp_get_instance_private(self);
 
 	if (req_frame == NULL || *resp_frame == NULL ||
@@ -344,6 +346,8 @@ void hinawa_fw_fcp_bind(HinawaFwFcp *self, HinawaFwNode *node,
 	HinawaFwFcpPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_FCP(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_fw_fcp_get_instance_private(self);
 
 	if (priv->node == NULL) {

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -206,16 +206,13 @@ void hinawa_fw_fcp_transaction(HinawaFwFcp *self,
 	gint64 expiration;
 
 	g_return_if_fail(HINAWA_IS_FW_FCP(self));
+	g_return_if_fail(req_frame != NULL);
+	g_return_if_fail(req_frame_size > 0 && req_frame_size < FCP_MAXIMUM_FRAME_BYTES);
+	g_return_if_fail(resp_frame != NULL);
+	g_return_if_fail(resp_frame_size != NULL && *resp_frame_size > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_fw_fcp_get_instance_private(self);
-
-	if (req_frame == NULL || *resp_frame == NULL ||
-	    req_frame_size == 0 || *resp_frame_size == 0 ||
-	    req_frame_size > FCP_MAXIMUM_FRAME_BYTES) {
-		raise(exception, EINVAL);
-		return;
-	}
 
 	g_object_get(G_OBJECT(self), "timeout", &timeout_ms, NULL);
 
@@ -346,6 +343,7 @@ void hinawa_fw_fcp_bind(HinawaFwFcp *self, HinawaFwNode *node,
 	HinawaFwFcpPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_FCP(self));
+	g_return_if_fail(node != NULL);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_fw_fcp_get_instance_private(self);

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -33,6 +33,10 @@ G_BEGIN_DECLS
 				   HINAWA_TYPE_FW_FCP,		\
 				   HinawaFwFcpClass))
 
+#define HINAWA_FW_FCP_ERROR	hinawa_fw_fcp_error_quark()
+
+GQuark hinawa_fw_fcp_error_quark();
+
 typedef struct _HinawaFwFcp		HinawaFwFcp;
 typedef struct _HinawaFwFcpClass	HinawaFwFcpClass;
 typedef struct _HinawaFwFcpPrivate	HinawaFwFcpPrivate;

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -275,6 +275,7 @@ void hinawa_fw_node_open(HinawaFwNode *self, const gchar *path,
 	HinawaFwNodePrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_NODE(self));
+	g_return_if_fail(path != NULL && strlen(path) > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_fw_node_get_instance_private(self);
@@ -313,17 +314,14 @@ void hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
 	HinawaFwNodePrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_NODE(self));
+	g_return_if_fail(image != NULL);
+	g_return_if_fail(length != NULL);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_fw_node_get_instance_private(self);
 
 	if (priv->fd < 0) {
 		raise(exception, ENXIO);
-		return;
-	}
-
-	if (image == NULL || length == NULL) {
-		raise(exception, EINVAL);
 		return;
 	}
 
@@ -449,6 +447,7 @@ void hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc,
 	FwNodeSource *src;
 
 	g_return_if_fail(HINAWA_IS_FW_NODE(self));
+	g_return_if_fail(gsrc != NULL);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_fw_node_get_instance_private(self);

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -474,12 +474,13 @@ void hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc,
 }
 
 // Internal use only.
-void hinawa_fw_node_ioctl(HinawaFwNode *self, unsigned long req, void *args,
-			  int *err)
+void hinawa_fw_node_ioctl(HinawaFwNode *self, unsigned long req, void *args, GError **exception)
 {
 	HinawaFwNodePrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_NODE(self));
+	g_return_if_fail(exception != NULL);
+
 	priv = hinawa_fw_node_get_instance_private(self);
 
 	// To invalidate the transaction in a case of timeout.
@@ -489,9 +490,8 @@ void hinawa_fw_node_ioctl(HinawaFwNode *self, unsigned long req, void *args,
 		priv->transactions = g_list_prepend(priv->transactions, req);
 	}
 
-	*err = 0;
 	if (ioctl(priv->fd, req, args) < 0)
-		*err = -errno;
+		raise(exception, errno);
 }
 
 void hinawa_fw_node_invalidate_transaction(HinawaFwNode *self, HinawaFwReq *req)

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -463,11 +463,6 @@ void hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc,
         // transaction frame.
         src->len = sysconf(_SC_PAGESIZE);
         src->buf = g_malloc0(src->len);
-        if (src->buf == NULL) {
-                raise(exception, ENOMEM);
-		g_source_unref(*gsrc);
-                return;
-        }
 
 	src->self = self;
 	src->tag = g_source_add_unix_fd(*gsrc, priv->fd, G_IO_IN);

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -275,6 +275,8 @@ void hinawa_fw_node_open(HinawaFwNode *self, const gchar *path,
 	HinawaFwNodePrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_NODE(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_fw_node_get_instance_private(self);
 
 	if (priv->fd >= 0) {
@@ -311,6 +313,8 @@ void hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
 	HinawaFwNodePrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_NODE(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_fw_node_get_instance_private(self);
 
 	if (priv->fd < 0) {
@@ -445,6 +449,8 @@ void hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc,
 	FwNodeSource *src;
 
 	g_return_if_fail(HINAWA_IS_FW_NODE(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_fw_node_get_instance_private(self);
 
 	if (priv->fd < 0) {

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -406,8 +406,10 @@ static gboolean dispatch_src(GSource *gsrc, GSourceFunc cb, gpointer user_data)
 		g_mutex_unlock(&priv->transactions_mutex);
 	}
 
-	if (exception != NULL)
+	if (exception != NULL) {
+		g_clear_error(&exception);
 		return G_SOURCE_REMOVE;
+	}
 
 	// Just be sure to continue to process this source.
 	return G_SOURCE_CONTINUE;

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -29,6 +29,10 @@ G_BEGIN_DECLS
 				   HINAWA_TYPE_FW_NODE,		\
 				   HinawaFwNodeClass))
 
+#define HINAWA_FW_NODE_ERROR	hinawa_fw_node_error_quark()
+
+GQuark hinawa_fw_node_error_quark();
+
 typedef struct _HinawaFwNode		HinawaFwNode;
 typedef struct _HinawaFwNodeClass	HinawaFwNodeClass;
 typedef struct _HinawaFwNodePrivate	HinawaFwNodePrivate;

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -168,7 +168,6 @@ void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 	HinawaFwReqPrivate *priv;
 	guint64 generation;
 	guint64 expiration;
-	int err = 0;
 
 	g_return_if_fail(HINAWA_IS_FW_REQ(self));
 	priv = hinawa_fw_req_get_instance_private(self);
@@ -253,11 +252,10 @@ void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 	g_mutex_lock(&priv->mutex);
 
 	// Send this transaction.
-	hinawa_fw_node_ioctl(node, FW_CDEV_IOC_SEND_REQUEST, &req, &err);
-	if (err < 0) {
+	hinawa_fw_node_ioctl(node, FW_CDEV_IOC_SEND_REQUEST, &req, exception);
+	if (*exception != NULL) {
 		g_mutex_unlock(&priv->mutex);
 		g_cond_clear(&priv->cond);
-		raise(exception, -err);
 		goto end;
 	}
 

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -257,7 +257,7 @@ void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 	if (err < 0) {
 		g_mutex_unlock(&priv->mutex);
 		g_cond_clear(&priv->cond);
-		raise(exception, err);
+		raise(exception, -err);
 		goto end;
 	}
 

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -170,6 +170,8 @@ void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 	guint64 expiration;
 
 	g_return_if_fail(HINAWA_IS_FW_REQ(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_fw_req_get_instance_private(self);
 
 	if (length == 0 || *frame == NULL || *frame_size == 0) {

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -32,6 +32,10 @@ G_BEGIN_DECLS
 				   HINAWA_TYPE_FW_REQ,		\
 				   HinawaFwReqClass))
 
+#define HINAWA_FW_REQ_ERROR	hinawa_fw_req_error_quark()
+
+GQuark hinawa_fw_req_error_quark();
+
 typedef struct _HinawaFwReq		HinawaFwReq;
 typedef struct _HinawaFwReqClass	HinawaFwReqClass;
 typedef struct _HinawaFwReqPrivate	HinawaFwReqPrivate;

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -175,18 +175,8 @@ void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
 	priv->node = g_object_ref(node);
 
 	priv->req_frame = g_malloc(allocate.length);
-	if (!priv->req_frame) {
-		raise(exception, ENOMEM);
-		hinawa_fw_resp_release(self);
-		return;
-	}
 
 	priv->resp_frame = g_malloc0(allocate.length);
-	if (!priv->resp_frame) {
-		raise(exception, ENOMEM);
-		hinawa_fw_resp_release(self);
-		return;
-	}
 
 	priv->width = allocate.length;
 	priv->addr_handle = allocate.handle;

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -156,6 +156,8 @@ void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
 	struct fw_cdev_allocate allocate = {0};
 
 	g_return_if_fail(HINAWA_IS_FW_RESP(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_fw_resp_get_instance_private(self);
 
 	if (priv->node != NULL) {

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -156,14 +156,11 @@ void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
 	struct fw_cdev_allocate allocate = {0};
 
 	g_return_if_fail(HINAWA_IS_FW_RESP(self));
+	g_return_if_fail(width > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_fw_resp_get_instance_private(self);
-
-	if (priv->node != NULL) {
-		raise(exception, EINVAL);
-		return;
-	}
+	g_return_if_fail(priv->node == NULL);
 
 	allocate.offset = addr;
 	allocate.closure = (guint64)self;
@@ -235,6 +232,9 @@ void hinawa_fw_resp_get_req_frame(HinawaFwResp *self, const guint8 **frame,
 	HinawaFwRespPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_RESP(self));
+	g_return_if_fail(frame != NULL);
+	g_return_if_fail(length != NULL);
+
 	priv = hinawa_fw_resp_get_instance_private(self);
 
 	if (frame && length && priv->req_length > 0) {
@@ -258,6 +258,9 @@ void hinawa_fw_resp_set_resp_frame(HinawaFwResp *self, guint8 *frame,
 	HinawaFwRespPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_FW_RESP(self));
+	g_return_if_fail(frame != NULL);
+	g_return_if_fail(length > 0);
+
 	priv = hinawa_fw_resp_get_instance_private(self);
 
 	if (frame && length <= priv->width) {

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -19,12 +19,6 @@
  * utilize ioctl(2) with subsystem specific request commands.
  */
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaFwResp", hinawa_fw_resp)
-#define raise(exception, errno)						\
-	g_set_error(exception, hinawa_fw_resp_quark(), errno,		\
-		    "%d: %s", __LINE__, strerror(errno))
-
 struct _HinawaFwRespPrivate {
 	HinawaFwNode *node;
 
@@ -142,7 +136,8 @@ HinawaFwResp *hinawa_fw_resp_new(void)
  * @node: A #HinawaFwNode.
  * @addr: A start address to listen to in host controller.
  * @width: The byte width of address to listen to host controller.
- * @exception: A #GError.
+ * @exception: A #GError. Error can be generated with two domains; #g_file_error_quark() and
+ *	       #hinawa_fw_node_error_quark().
  *
  * Start to listen to a range of address in host controller which connects to
  * the node.

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -171,7 +171,7 @@ void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
 
 	hinawa_fw_node_ioctl(node, FW_CDEV_IOC_ALLOCATE, &allocate, &err);
 	if (err < 0) {
-		raise(exception, err);
+		raise(exception, -err);
 		return;
 	}
 	priv->node = g_object_ref(node);

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -3,7 +3,6 @@ HINAWA_0_6_0 {
     "hinawa_fw_req_get_type";
 
     "hinawa_fw_resp_get_type";
-    "hinawa_fw_resp_quark";
 
     "hinawa_fw_fcp_get_type";
     "hinawa_fw_fcp_quark";

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -72,7 +72,6 @@ HINAWA_1_3_0 {
 HINAWA_1_4_0 {
     "hinawa_fw_node_get_type";
     "hinawa_fw_node_new";
-    "hinawa_fw_node_quark";
     "hinawa_fw_node_open";
     "hinawa_fw_node_create_source";
 
@@ -100,3 +99,8 @@ HINAWA_2_0_0 {
 
     "hinawa_snd_unit_get_node";
 } HINAWA_1_4_0;
+
+HINAWA_2_1_0 {
+    "hinawa_fw_node_error_get_type";
+    "hinawa_fw_node_error_quark";
+} HINAWA_2_0_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -8,7 +8,6 @@ HINAWA_0_6_0 {
 
     "hinawa_snd_unit_get_type";
     "hinawa_snd_unit_open";
-    "hinawa_snd_unit_quark";
     "hinawa_snd_unit_lock";
     "hinawa_snd_unit_unlock";
 
@@ -105,4 +104,7 @@ HINAWA_2_1_0 {
 
     "hinawa_fw_fcp_error_get_type";
     "hinawa_fw_fcp_error_quark";
+
+    "hinawa_snd_unit_error_get_type";
+    "hinawa_snd_unit_error_quark";
 } HINAWA_2_0_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -13,7 +13,6 @@ HINAWA_0_6_0 {
 
     "hinawa_snd_dice_get_type";
     "hinawa_snd_dice_open";
-    "hinawa_snd_dice_quark";
 
     "hinawa_snd_efw_get_type";
     "hinawa_snd_efw_open";
@@ -107,4 +106,7 @@ HINAWA_2_1_0 {
 
     "hinawa_snd_unit_error_get_type";
     "hinawa_snd_unit_error_quark";
+
+    "hinawa_snd_dice_error_get_type";
+    "hinawa_snd_dice_error_quark";
 } HINAWA_2_0_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -1,7 +1,6 @@
 HINAWA_0_6_0 {
   global:
     "hinawa_fw_req_get_type";
-    "hinawa_fw_req_quark";
 
     "hinawa_fw_resp_get_type";
     "hinawa_fw_resp_quark";
@@ -103,4 +102,6 @@ HINAWA_2_0_0 {
 HINAWA_2_1_0 {
     "hinawa_fw_node_error_get_type";
     "hinawa_fw_node_error_quark";
+
+    "hinawa_fw_req_error_quark";
 } HINAWA_2_0_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -30,7 +30,6 @@ HINAWA_0_8_0 {
   global:
     "hinawa_snd_motu_get_type";
     "hinawa_snd_motu_open";
-    "hinawa_snd_motu_quark";
 } HINAWA_0_7_0;
 
 HINAWA_1_0_0 {

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -5,7 +5,6 @@ HINAWA_0_6_0 {
     "hinawa_fw_resp_get_type";
 
     "hinawa_fw_fcp_get_type";
-    "hinawa_fw_fcp_quark";
 
     "hinawa_snd_unit_get_type";
     "hinawa_snd_unit_open";
@@ -103,4 +102,7 @@ HINAWA_2_1_0 {
     "hinawa_fw_node_error_quark";
 
     "hinawa_fw_req_error_quark";
+
+    "hinawa_fw_fcp_error_get_type";
+    "hinawa_fw_fcp_error_quark";
 } HINAWA_2_0_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -24,7 +24,6 @@ HINAWA_0_7_0 {
   global:
     "hinawa_snd_dg00x_get_type";
     "hinawa_snd_dg00x_open";
-    "hinawa_snd_dg00x_quark";
 } HINAWA_0_6_0;
 
 HINAWA_0_8_0 {

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -16,7 +16,6 @@ HINAWA_0_6_0 {
 
     "hinawa_snd_efw_get_type";
     "hinawa_snd_efw_open";
-    "hinawa_snd_efw_quark";
   local:
     *;
 };
@@ -109,4 +108,7 @@ HINAWA_2_1_0 {
 
     "hinawa_snd_dice_error_get_type";
     "hinawa_snd_dice_error_quark";
+
+    "hinawa_snd_efw_error_get_type";
+    "hinawa_snd_efw_error_quark";
 } HINAWA_2_0_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -44,7 +44,6 @@ HINAWA_1_0_0 {
 HINAWA_1_1_0 {
     "hinawa_snd_tscm_get_type";
     "hinawa_snd_tscm_open";
-    "hinawa_snd_tscm_quark";
     "hinawa_sigs_marshal_VOID__UINT_UINT_UINT";
     "hinawa_snd_tscm_get_state";
 } HINAWA_1_0_0;

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -63,6 +63,7 @@ typedef enum {
  * @HINAWA_FW_RCODE_BUSY:		For busyness.
  * @HINAWA_FW_RCODE_GENERATION:		For generation.
  * @HINAWA_FW_RCODE_NO_ACK:		For no acknowledge.
+ * @HINAWA_FW_RCODE_INVALID:		For rcode out of specification.
  *
  * A representation for rcode of asynchronous transaction on IEEE 1394 bus.
  *
@@ -78,6 +79,7 @@ typedef enum {
 	HINAWA_FW_RCODE_BUSY		= RCODE_BUSY,
 	HINAWA_FW_RCODE_GENERATION	= RCODE_GENERATION,
 	HINAWA_FW_RCODE_NO_ACK		= RCODE_NO_ACK,
+	HINAWA_FW_RCODE_INVALID,
 } HinawaFwRcode;
 
 /**

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -132,4 +132,26 @@ typedef enum {
 	HINAWA_FW_FCP_ERROR_LARGE_RESP,
 } HinawaFwFcpError;
 
+/**
+ * HinawaSndUnitError:
+ * @HINAWA_SND_UNIT_ERROR_DISCONNECTED:	The hwdep device associated to the instance is disconnected.
+ * @HINAWA_SND_UNIT_ERROR_OPENED:	The instance is already associated to unit by opening hwdep
+ *					character device.
+ * @HINAWA_SND_UNIT_ERROR_NOT_OPENED:	The instance is not associated to unit yet by opening hwdep
+ *					character device.
+ * @HINAWA_SND_UNIT_ERROR_LOCKED:	The hwdep device is already locked for kernel packet streaming.
+ * @HINAWA_SND_UNIT_ERROR_UNLOCKED:	The hwdep device is not locked for kernel packet streaming yet.
+ * @HINAWA_SND_UNIT_ERROR_WRONG_CLASS:	The hwdep device is not for the unit expected by the class.
+ *
+ * A set of error code for GError with domain of #HinawaSndUnitError.
+ */
+typedef enum {
+	HINAWA_SND_UNIT_ERROR_DISCONNECTED,
+	HINAWA_SND_UNIT_ERROR_OPENED,
+	HINAWA_SND_UNIT_ERROR_NOT_OPENED,
+	HINAWA_SND_UNIT_ERROR_LOCKED,
+	HINAWA_SND_UNIT_ERROR_UNLOCKED,
+	HINAWA_SND_UNIT_ERROR_WRONG_CLASS,
+} HinawaSndUnitError;
+
 #endif

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -164,4 +164,44 @@ typedef enum {
 	HINAWA_SND_DICE_ERROR_TIMEOUT,
 } HinawaSndDiceError;
 
+/**
+ * HinawaSndEfwError:
+ * @HINAWA_SND_EFW_ERROR_BAD:			The request or response includes invalid header.
+ * @HINAWA_SND_EFW_ERROR_BAD_COMMAND:		The request includes invalid category or command.
+ * @HINAWA_SND_EFW_ERROR_COMM_ERR:		The transaction fails due to communication error.
+ * @HINAWA_SND_EFW_ERROR_BAD_QUAD_COUNT:	The number of quadlets in transaction is invalid.
+ * @HINAWA_SND_EFW_ERROR_UNSUPPORTED:		The request is not supported.
+ * @HINAWA_SND_EFW_ERROR_1394_TIMEOUT:		The transaction is canceled due to response timeout.
+ * @HINAWA_SND_EFW_ERROR_DSP_TIMEOUT:		The operation for DSP did not finish within timeout.
+ * @HINAWA_SND_EFW_ERROR_BAD_RATE:		The request includes invalid value for sampling frequency.
+ * @HINAWA_SND_EFW_ERROR_BAD_CLOCK:		The request includes invalid value for source of clock.
+ * @HINAWA_SND_EFW_ERROR_BAD_CHANNEL:		The request includes invalid value for the number of channel.
+ * @HINAWA_SND_EFW_ERROR_BAD_PAN:		The request includes invalid value for panning.
+ * @HINAWA_SND_EFW_ERROR_FLASH_BUSY:		The on-board flash is busy and not operable.
+ * @HINAWA_SND_EFW_ERROR_BAD_MIRROR:		The request includes invalid value for mirroring channel.
+ * @HINAWA_SND_EFW_ERROR_BAD_LED:		The request includes invalid value for LED.
+ * @HINAWA_SND_EFW_ERROR_BAD_PARAMETER:		The request includes invalid value of parameter.
+ * @HINAWA_SND_EFW_ERROR_LARGE_RESP:		The size of response is larger than expected.
+ *
+ * A set of error code for GError with domain which equals to #hinawa_snd_efw_error_quark();
+ */
+typedef enum {
+	HINAWA_SND_EFW_ERROR_BAD		= 1,
+	HINAWA_SND_EFW_ERROR_BAD_COMMAND	= 2,
+	HINAWA_SND_EFW_ERROR_COMM_ERR		= 3,
+	HINAWA_SND_EFW_ERROR_BAD_QUAD_COUNT	= 4,
+	HINAWA_SND_EFW_ERROR_UNSUPPORTED	= 5,
+	HINAWA_SND_EFW_ERROR_TIMEOUT		= 6,
+	HINAWA_SND_EFW_ERROR_DSP_TIMEOUT	= 7,
+	HINAWA_SND_EFW_ERROR_BAD_RATE		= 8,
+	HINAWA_SND_EFW_ERROR_BAD_CLOCK		= 9,
+	HINAWA_SND_EFW_ERROR_BAD_CHANNEL	= 10,
+	HINAWA_SND_EFW_ERROR_BAD_PAN		= 11,
+	HINAWA_SND_EFW_ERROR_FLASH_BUSY		= 12,
+	HINAWA_SND_EFW_ERROR_BAD_MIRROR		= 13,
+	HINAWA_SND_EFW_ERROR_BAD_LED		= 14,
+	HINAWA_SND_EFW_ERROR_BAD_PARAMETER	= 15,
+	HINAWA_SND_EFW_ERROR_LARGE_RESP,
+} HinawaSndEfwError;
+
 #endif

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -104,4 +104,20 @@ typedef enum {
 	HINAWA_SND_UNIT_TYPE_FIREFACE	= SNDRV_FIREWIRE_TYPE_FIREFACE,
 } HinawaSndUnitType;
 
+/**
+ * HinawaFwNodeError:
+ * @HINAWA_FW_NODE_ERROR_DISCONNECTED:	The node associated to the instance is disconnected.
+ * @HINAWA_FW_NODE_ERROR_OPENED:	The instance is already associated to node by opening
+ *					firewire character device.
+ * @HINAWA_FW_NODE_ERROR_NOT_OPENED:	The instance is not associated to node by opening
+ *					firewire character device.
+ *
+ * A set of error code for GError with domain which equals to #hinawa_fw_node_error_quark().
+ */
+typedef enum {
+	HINAWA_FW_NODE_ERROR_DISCONNECTED,
+	HINAWA_FW_NODE_ERROR_OPENED,
+	HINAWA_FW_NODE_ERROR_NOT_OPENED,
+} HinawaFwNodeError;
+
 #endif

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -154,4 +154,14 @@ typedef enum {
 	HINAWA_SND_UNIT_ERROR_WRONG_CLASS,
 } HinawaSndUnitError;
 
+/**
+ * HinawaSndDiceError:
+ * @HINAWA_SND_DICE_ERROR_TIMEOUT:	The transaction is canceled due to response timeout.
+ *
+ * A set of error code for GError with domain which equals to #hinawa_snd_dice_error_quark().
+ */
+typedef enum {
+	HINAWA_SND_DICE_ERROR_TIMEOUT,
+} HinawaSndDiceError;
+
 #endif

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -122,4 +122,14 @@ typedef enum {
 	HINAWA_FW_NODE_ERROR_NOT_OPENED,
 } HinawaFwNodeError;
 
+/**
+ * HinawaFwFcpError:
+ * @HINAWA_FW_FCP_ERROR_TIMEOUT:	The transaction is canceled due to response timeout.
+ * @HINAWA_FW_FCP_ERROR_LARGE_RESP:	The size of response is larger than expected.
+ */
+typedef enum {
+	HINAWA_FW_FCP_ERROR_TIMEOUT,
+	HINAWA_FW_FCP_ERROR_LARGE_RESP,
+} HinawaFwFcpError;
+
 #endif

--- a/src/internal.h
+++ b/src/internal.h
@@ -19,8 +19,7 @@
 #include "snd_motu.h"
 #include "snd_tscm.h"
 
-void hinawa_fw_node_ioctl(HinawaFwNode *self, unsigned long req, void *args,
-			  int *err);
+void hinawa_fw_node_ioctl(HinawaFwNode *self, unsigned long req, void *args, GError **exception);
 void hinawa_fw_node_invalidate_transaction(HinawaFwNode *self, HinawaFwReq *req);
 
 void hinawa_fw_resp_handle_request(HinawaFwResp *self,

--- a/src/snd_dg00x.c
+++ b/src/snd_dg00x.c
@@ -71,7 +71,8 @@ HinawaSndDg00x *hinawa_snd_dg00x_new(void)
  * hinawa_snd_dg00x_open:
  * @self: A #HinawaSndUnit
  * @path: A full path of a special file for ALSA hwdep character device
- * @exception: A #GError
+ * @exception: A #GError. Error can be generated with three domains; #g_file_error_quark(),
+ *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Dg00x  devices.
  */

--- a/src/snd_dg00x.c
+++ b/src/snd_dg00x.c
@@ -16,12 +16,6 @@
 
 G_DEFINE_TYPE(HinawaSndDg00x, hinawa_snd_dg00x, HINAWA_TYPE_SND_UNIT)
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaSndDg00x", hinawa_snd_dg00x)
-#define raise(exception, errno)						\
-	g_set_error(exception, hinawa_snd_dg00x_quark(), errno,		\
-		    "%d: %s", __LINE__, strerror(errno))
-
 /* This object has one signal. */
 enum dg00x_sig_type {
 	DG00X_SIG_TYPE_MESSAGE,

--- a/src/snd_dg00x.c
+++ b/src/snd_dg00x.c
@@ -78,6 +78,7 @@ HinawaSndDg00x *hinawa_snd_dg00x_new(void)
 void hinawa_snd_dg00x_open(HinawaSndDg00x *self, gchar *path, GError **exception)
 {
 	g_return_if_fail(HINAWA_IS_SND_DG00X(self));
+	g_return_if_fail(path != NULL && strlen(path) > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);

--- a/src/snd_dg00x.c
+++ b/src/snd_dg00x.c
@@ -77,19 +77,9 @@ HinawaSndDg00x *hinawa_snd_dg00x_new(void)
  */
 void hinawa_snd_dg00x_open(HinawaSndDg00x *self, gchar *path, GError **exception)
 {
-	int type;
-
 	g_return_if_fail(HINAWA_IS_SND_DG00X(self));
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
-	if (*exception != NULL)
-		return;
-
-	g_object_get(G_OBJECT(self), "type", &type, NULL);
-	if (type != SNDRV_FIREWIRE_TYPE_DIGI00X) {
-		raise(exception, EINVAL);
-		return;
-	}
 }
 
 void hinawa_snd_dg00x_handle_msg(HinawaSndDg00x *self, const void *buf,

--- a/src/snd_dg00x.c
+++ b/src/snd_dg00x.c
@@ -78,6 +78,7 @@ HinawaSndDg00x *hinawa_snd_dg00x_new(void)
 void hinawa_snd_dg00x_open(HinawaSndDg00x *self, gchar *path, GError **exception)
 {
 	g_return_if_fail(HINAWA_IS_SND_DG00X(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
 }

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -158,10 +158,6 @@ void hinawa_snd_dice_transaction(HinawaSndDice *self, guint64 addr,
 	// Alignment data on given buffer to local buffer for transaction.
 	length = frame_count * sizeof(*frame);
 	req_frame = g_malloc0(length);
-	if (req_frame == NULL) {
-		raise(exception, ENOMEM);
-		return;
-	}
 	for (i = 0; i < frame_count; ++i) {
 		__be32 quad = GUINT32_TO_BE(frame[i]);
 		memcpy(req_frame + i * sizeof(quad), &quad, sizeof(quad));

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -97,7 +97,8 @@ HinawaSndDice *hinawa_snd_dice_new(void)
  * hinawa_snd_dice_open:
  * @self: A #HinawaSndUnit
  * @path: A full path of a special file for ALSA hwdep character device
- * @exception: A #GError
+ * @exception: A #GError. Error can be generated with three domains; #g_file_error_quark(),
+ *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Dice  devices.
  */

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -106,6 +106,8 @@ void hinawa_snd_dice_open(HinawaSndDice *self, gchar *path, GError **exception)
 	HinawaSndDicePrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_SND_DICE(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_dice_get_instance_private(self);
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
@@ -148,6 +150,8 @@ void hinawa_snd_dice_transaction(HinawaSndDice *self, guint64 addr,
 	gint64 expiration;
 
 	g_return_if_fail(HINAWA_IS_SND_DICE(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_dice_get_instance_private(self);
 
 	if (frame_count == 1)

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -106,6 +106,7 @@ void hinawa_snd_dice_open(HinawaSndDice *self, gchar *path, GError **exception)
 	HinawaSndDicePrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_SND_DICE(self));
+	g_return_if_fail(path != NULL && strlen(path) > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_snd_dice_get_instance_private(self);
@@ -150,6 +151,8 @@ void hinawa_snd_dice_transaction(HinawaSndDice *self, guint64 addr,
 	gint64 expiration;
 
 	g_return_if_fail(HINAWA_IS_SND_DICE(self));
+	g_return_if_fail(frame != NULL);
+	g_return_if_fail(frame_count > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_snd_dice_get_instance_private(self);

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -104,7 +104,6 @@ HinawaSndDice *hinawa_snd_dice_new(void)
 void hinawa_snd_dice_open(HinawaSndDice *self, gchar *path, GError **exception)
 {
 	HinawaSndDicePrivate *priv;
-	int type;
 
 	g_return_if_fail(HINAWA_IS_SND_DICE(self));
 	priv = hinawa_snd_dice_get_instance_private(self);
@@ -112,12 +111,6 @@ void hinawa_snd_dice_open(HinawaSndDice *self, gchar *path, GError **exception)
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
 	if (*exception != NULL)
 		return;
-
-	g_object_get(G_OBJECT(self), "type", &type, NULL);
-	if (type != SNDRV_FIREWIRE_TYPE_DICE) {
-		raise(exception, EINVAL);
-		return;
-	}
 
 	priv->req = g_object_new(HINAWA_TYPE_FW_REQ, NULL);
 

--- a/src/snd_dice.h
+++ b/src/snd_dice.h
@@ -31,6 +31,10 @@ G_BEGIN_DECLS
 				   HINAWA_TYPE_SND_DICE,	\
 				   HinawaSndDiceClass))
 
+#define HINAWA_SND_DICE_ERROR	hinawa_snd_dice_error_quark()
+
+GQuark hinawa_snd_dice_error_quark();
+
 typedef struct _HinawaSndDice		HinawaSndDice;
 typedef struct _HinawaSndDiceClass	HinawaSndDiceClass;
 typedef struct _HinawaSndDicePrivate	HinawaSndDicePrivate;

--- a/src/snd_efw.c
+++ b/src/snd_efw.c
@@ -112,6 +112,7 @@ void hinawa_snd_efw_open(HinawaSndEfw *self, gchar *path, GError **exception)
 	HinawaSndEfwPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_SND_EFW(self));
+	g_return_if_fail(path != NULL && strlen(path) > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_snd_efw_get_instance_private(self);
@@ -161,14 +162,11 @@ void hinawa_snd_efw_transaction(HinawaSndEfw *self,
 	guint32 status;
 
 	g_return_if_fail(HINAWA_IS_SND_EFW(self));
+	g_return_if_fail(params != NULL);
+	g_return_if_fail(param_count != NULL && *param_count > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_snd_efw_get_instance_private(self);
-
-	if (*params == NULL || *param_count == 0) {
-		raise(exception, EINVAL);
-		return;
-	}
 
 	trans.frame = g_malloc0(MAXIMUM_FRAME_BYTES);
 

--- a/src/snd_efw.c
+++ b/src/snd_efw.c
@@ -110,7 +110,6 @@ HinawaSndEfw *hinawa_snd_efw_new(void)
 void hinawa_snd_efw_open(HinawaSndEfw *self, gchar *path, GError **exception)
 {
 	HinawaSndEfwPrivate *priv;
-	int type;
 
 	g_return_if_fail(HINAWA_IS_SND_EFW(self));
 	priv = hinawa_snd_efw_get_instance_private(self);
@@ -118,12 +117,6 @@ void hinawa_snd_efw_open(HinawaSndEfw *self, gchar *path, GError **exception)
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
 	if (*exception != NULL)
 		return;
-
-	g_object_get(G_OBJECT(self), "type", &type, NULL);
-	if (type != SNDRV_FIREWIRE_TYPE_FIREWORKS) {
-		raise(exception, EINVAL);
-		return;
-	}
 
 	priv = hinawa_snd_efw_get_instance_private(self);
 	priv->seqnum = 0;

--- a/src/snd_efw.c
+++ b/src/snd_efw.c
@@ -103,7 +103,8 @@ HinawaSndEfw *hinawa_snd_efw_new(void)
  * hinawa_snd_efw_open:
  * @self: A #HinawaSndUnit
  * @path: A full path of a special file for ALSA hwdep character device
- * @exception: A #GError
+ * @exception: A #GError. Error can be generated with three domains; #g_file_error_quark(),
+ *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Fireworks devices.
  */

--- a/src/snd_efw.c
+++ b/src/snd_efw.c
@@ -167,10 +167,6 @@ void hinawa_snd_efw_transaction(HinawaSndEfw *self,
 	}
 
 	trans.frame = g_malloc0(MAXIMUM_FRAME_BYTES);
-	if (trans.frame == NULL) {
-		raise(exception, ENOMEM);
-		return;
-	}
 
 	quads = sizeof(*trans.frame) / 4;
 	if (args)

--- a/src/snd_efw.c
+++ b/src/snd_efw.c
@@ -112,6 +112,8 @@ void hinawa_snd_efw_open(HinawaSndEfw *self, gchar *path, GError **exception)
 	HinawaSndEfwPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_SND_EFW(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_efw_get_instance_private(self);
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
@@ -159,6 +161,8 @@ void hinawa_snd_efw_transaction(HinawaSndEfw *self,
 	guint32 status;
 
 	g_return_if_fail(HINAWA_IS_SND_EFW(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_efw_get_instance_private(self);
 
 	if (*params == NULL || *param_count == 0) {

--- a/src/snd_efw.h
+++ b/src/snd_efw.h
@@ -31,6 +31,10 @@ G_BEGIN_DECLS
 				   HINAWA_TYPE_SND_EFW,		\
 				   HinawaSndEfwClass))
 
+#define HINAWA_SND_EFW_ERROR	hinawa_snd_efw_error_quark()
+
+GQuark hinawa_snd_efw_error_quark();
+
 typedef struct _HinawaSndEfw		HinawaSndEfw;
 typedef struct _HinawaSndEfwClass	HinawaSndEfwClass;
 typedef struct _HinawaSndEfwPrivate	HinawaSndEfwPrivate;

--- a/src/snd_motu.c
+++ b/src/snd_motu.c
@@ -81,6 +81,7 @@ HinawaSndMotu *hinawa_snd_motu_new(void)
 void hinawa_snd_motu_open(HinawaSndMotu *self, gchar *path, GError **exception)
 {
 	g_return_if_fail(HINAWA_IS_SND_MOTU(self));
+	g_return_if_fail(path != NULL && strlen(path) > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);

--- a/src/snd_motu.c
+++ b/src/snd_motu.c
@@ -14,12 +14,6 @@
  * Mark of the Unicorn (MOTU). This inherits #HinawaSndUnit.
  */
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaSndMotu", hinawa_snd_motu)
-#define raise(exception, errno)						\
-	g_set_error(exception, hinawa_snd_motu_quark(), errno,		\
-		    "%d: %s", __LINE__, strerror(errno))
-
 struct _HinawaSndMotuPrivate {
 	struct snd_firewire_motu_status *status;
 };

--- a/src/snd_motu.c
+++ b/src/snd_motu.c
@@ -80,19 +80,9 @@ HinawaSndMotu *hinawa_snd_motu_new(void)
  */
 void hinawa_snd_motu_open(HinawaSndMotu *self, gchar *path, GError **exception)
 {
-	int type;
-
 	g_return_if_fail(HINAWA_IS_SND_MOTU(self));
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
-	if (*exception != NULL)
-		return;
-
-	g_object_get(G_OBJECT(self), "type", &type, NULL);
-	if (type != SNDRV_FIREWIRE_TYPE_MOTU) {
-		raise(exception, EINVAL);
-		return;
-	}
 }
 
 void hinawa_snd_motu_handle_notification(HinawaSndMotu *self,

--- a/src/snd_motu.c
+++ b/src/snd_motu.c
@@ -81,6 +81,7 @@ HinawaSndMotu *hinawa_snd_motu_new(void)
 void hinawa_snd_motu_open(HinawaSndMotu *self, gchar *path, GError **exception)
 {
 	g_return_if_fail(HINAWA_IS_SND_MOTU(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
 }

--- a/src/snd_motu.c
+++ b/src/snd_motu.c
@@ -74,7 +74,8 @@ HinawaSndMotu *hinawa_snd_motu_new(void)
  * hinawa_snd_motu_open:
  * @self: A #HinawaSndUnit
  * @path: A full path of a special file for ALSA hwdep character device
- * @exception: A #GError
+ * @exception: A #GError. Error can be generated with three domains; #g_file_error_quark(),
+ *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Motu devices.
  */

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -86,19 +86,9 @@ HinawaSndTscm *hinawa_snd_tscm_new(void)
  */
 void hinawa_snd_tscm_open(HinawaSndTscm *self, gchar *path, GError **exception)
 {
-	int type;
-
 	g_return_if_fail(HINAWA_IS_SND_TSCM(self));
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
-	if (*exception != NULL)
-		return;
-
-	g_object_get(G_OBJECT(self), "type", &type, NULL);
-	if (type != SNDRV_FIREWIRE_TYPE_TASCAM) {
-		raise(exception, EINVAL);
-		return;
-	}
 }
 
 /**

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -80,7 +80,8 @@ HinawaSndTscm *hinawa_snd_tscm_new(void)
  * hinawa_snd_tscm_open:
  * @self: A #HinawaSndUnit
  * @path: A full path of a special file for ALSA hwdep character device
- * @exception: A #GError
+ * @exception: A #GError. Error can be generated with three domains; #g_file_error_quark(),
+ *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Dg00x  devices.
  */

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -87,6 +87,7 @@ HinawaSndTscm *hinawa_snd_tscm_new(void)
 void hinawa_snd_tscm_open(HinawaSndTscm *self, gchar *path, GError **exception)
 {
 	g_return_if_fail(HINAWA_IS_SND_TSCM(self));
+	g_return_if_fail(path != NULL && strlen(path) > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
@@ -117,6 +118,8 @@ const guint32 *hinawa_snd_tscm_get_state(HinawaSndTscm *self,
 	hinawa_snd_unit_ioctl(&self->parent_instance,
 			      SNDRV_FIREWIRE_IOCTL_TASCAM_STATE, &priv->image,
 			      exception);
+	if (*exception != NULL)
+		return NULL;
 
 	for (i = 0; i < SNDRV_FIREWIRE_TASCAM_STATE_COUNT; ++i)
 		priv->state[i] = GUINT32_FROM_BE(priv->image.data[i]);

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -16,12 +16,6 @@
  * inherits #HinawaSndUnit.
  */
 
-/* For error handling. */
-G_DEFINE_QUARK("HinawaSndTscm", hinawa_snd_tscm)
-#define raise(exception, errno)					\
-	g_set_error(exception, hinawa_snd_tscm_quark(), errno,	\
-		    "%d: %s", __LINE__, strerror(errno))
-
 struct _HinawaSndTscmPrivate {
 	struct snd_firewire_tascam_state image;
 	guint32 state[SNDRV_FIREWIRE_TASCAM_STATE_COUNT];

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -87,6 +87,7 @@ HinawaSndTscm *hinawa_snd_tscm_new(void)
 void hinawa_snd_tscm_open(HinawaSndTscm *self, gchar *path, GError **exception)
 {
 	g_return_if_fail(HINAWA_IS_SND_TSCM(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	hinawa_snd_unit_open(&self->parent_instance, path, exception);
 }
@@ -109,6 +110,8 @@ const guint32 *hinawa_snd_tscm_get_state(HinawaSndTscm *self,
 	int i;
 
 	g_return_val_if_fail(HINAWA_IS_SND_TSCM(self), NULL);
+	g_return_val_if_fail(exception == NULL || *exception == NULL, NULL);
+
 	priv = hinawa_snd_tscm_get_instance_private(self);
 
 	hinawa_snd_unit_ioctl(&self->parent_instance,

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -216,6 +216,8 @@ void hinawa_snd_unit_open(HinawaSndUnit *self, gchar *path, GError **exception)
 	char fw_cdev[32];
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_unit_get_instance_private(self);
 
 	if (priv->fd >= 0) {
@@ -283,6 +285,8 @@ void hinawa_snd_unit_lock(HinawaSndUnit *self, GError **exception)
 	HinawaSndUnitPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_unit_get_instance_private(self);
 
 	if (priv->fd < 0) {
@@ -306,6 +310,8 @@ void hinawa_snd_unit_unlock(HinawaSndUnit *self, GError **exception)
 	HinawaSndUnitPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_unit_get_instance_private(self);
 
 	if (priv->fd < 0) {
@@ -325,6 +331,8 @@ void hinawa_snd_unit_write(HinawaSndUnit *self, const void *buf, size_t length,
 	ssize_t len;
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_unit_get_instance_private(self);
 
 	if (priv->fd < 0) {
@@ -345,6 +353,8 @@ void hinawa_snd_unit_ioctl(HinawaSndUnit *self, unsigned long request,
 	HinawaSndUnitPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_unit_get_instance_private(self);
 
 	if (priv->fd < 0) {
@@ -468,6 +478,8 @@ void hinawa_snd_unit_create_source(HinawaSndUnit *self, GSource **gsrc,
 	SndUnitSource *src;
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(exception == NULL || *exception == NULL);
+
 	priv = hinawa_snd_unit_get_instance_private(self);
 
 	if (priv->fd < 0) {

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -313,6 +313,7 @@ void hinawa_snd_unit_write(HinawaSndUnit *self, const void *buf, size_t length,
 			   GError **exception)
 {
 	HinawaSndUnitPrivate *priv;
+	ssize_t len;
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
 	priv = hinawa_snd_unit_get_instance_private(self);
@@ -322,8 +323,11 @@ void hinawa_snd_unit_write(HinawaSndUnit *self, const void *buf, size_t length,
 		return;
 	}
 
-	if (write(priv->fd, buf, length) != length)
+	len = write(priv->fd, buf, length);
+	if (len < 0)
 		raise(exception, errno);
+	else if (len != length)
+		raise(exception, EIO);
 }
 
 void hinawa_snd_unit_ioctl(HinawaSndUnit *self, unsigned long request,

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -486,11 +486,6 @@ void hinawa_snd_unit_create_source(HinawaSndUnit *self, GSource **gsrc,
 	src = (SndUnitSource *)(*gsrc);
 	src->len = sysconf(_SC_PAGESIZE);
 	src->buf = g_malloc(src->len);
-	if (src->buf == NULL) {
-		raise(exception, ENOMEM);
-		g_source_unref(*gsrc);
-		return;
-	}
 
 	src->unit = self;
 	src->tag = g_source_add_unix_fd(*gsrc, priv->fd, G_IO_IN);

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -235,6 +235,15 @@ void hinawa_snd_unit_open(HinawaSndUnit *self, gchar *path, GError **exception)
 		goto end;
 	}
 
+	if ((HINAWA_IS_SND_DICE(self) && priv->info.type != SNDRV_FIREWIRE_TYPE_DICE) ||
+	    (HINAWA_IS_SND_EFW(self) && priv->info.type != SNDRV_FIREWIRE_TYPE_FIREWORKS) ||
+	    (HINAWA_IS_SND_DG00X(self) && priv->info.type != SNDRV_FIREWIRE_TYPE_DIGI00X) ||
+	    (HINAWA_IS_SND_MOTU(self) && priv->info.type != SNDRV_FIREWIRE_TYPE_MOTU) ||
+	    (HINAWA_IS_SND_TSCM(self) && priv->info.type != SNDRV_FIREWIRE_TYPE_TASCAM)) {
+		raise(exception, EINVAL);
+		goto end;
+	}
+
 	snprintf(fw_cdev, sizeof(fw_cdev), "/dev/%s", priv->info.device_name);
 	hinawa_fw_node_open(priv->node, fw_cdev, exception);
 end:

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -216,6 +216,7 @@ void hinawa_snd_unit_open(HinawaSndUnit *self, gchar *path, GError **exception)
 	char fw_cdev[32];
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(path != NULL && strlen(path) > 0);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_snd_unit_get_instance_private(self);
@@ -269,6 +270,8 @@ void hinawa_snd_unit_get_node(HinawaSndUnit *self, HinawaFwNode **node)
 	HinawaSndUnitPrivate *priv;
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(node != NULL);
+
 	priv = hinawa_snd_unit_get_instance_private(self);
 
 	*node = priv->node;
@@ -478,6 +481,7 @@ void hinawa_snd_unit_create_source(HinawaSndUnit *self, GSource **gsrc,
 	SndUnitSource *src;
 
 	g_return_if_fail(HINAWA_IS_SND_UNIT(self));
+	g_return_if_fail(gsrc != NULL);
 	g_return_if_fail(exception == NULL || *exception == NULL);
 
 	priv = hinawa_snd_unit_get_instance_private(self);

--- a/src/snd_unit.h
+++ b/src/snd_unit.h
@@ -31,6 +31,10 @@ G_BEGIN_DECLS
 				   HINAWA_TYPE_SND_UNIT,	\
 				   HinawaSndUnitClass))
 
+#define HINAWA_SND_UNIT_ERROR	hinawa_snd_unit_error_quark()
+
+GQuark hinawa_snd_unit_error_quark();
+
 typedef struct _HinawaSndUnit		HinawaSndUnit;
 typedef struct _HinawaSndUnitClass	HinawaSndUnitClass;
 typedef struct _HinawaSndUnitPrivate	HinawaSndUnitPrivate;

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -65,12 +65,21 @@ fw_fcp_error_enumerators = (
     'LARGE_RESP',
 )
 
+snd_unit_error_enumerators = (
+    'DISCONNECTED',
+    'OPENED',
+    'NOT_OPENED',
+    'LOCKED',
+    'UNLOCKED',
+)
+
 types = {
     Hinawa.FwTcode: fw_tcode_enumerators,
     Hinawa.FwRcode: fw_rcode_enumerators,
     Hinawa.SndUnitType: snd_unit_type_enumerators,
     Hinawa.FwNodeError: fw_node_error_enumerators,
     Hinawa.FwFcpError: fw_fcp_error_enumerators,
+    Hinawa.SndUnitError: snd_unit_error_enumerators,
 }
 
 for obj, types in types.items():

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -77,6 +77,25 @@ snd_dice_error_enumerators = (
     'TIMEOUT',
 )
 
+snd_efw_error_enumerators = (
+    'BAD',
+    'BAD_COMMAND',
+    'COMM_ERR',
+    'BAD_QUAD_COUNT',
+    'UNSUPPORTED',
+    'TIMEOUT',
+    'DSP_TIMEOUT',
+    'BAD_RATE',
+    'BAD_CLOCK',
+    'BAD_CHANNEL',
+    'BAD_PAN',
+    'FLASH_BUSY',
+    'BAD_MIRROR',
+    'BAD_LED',
+    'BAD_PARAMETER',
+    'LARGE_RESP',
+)
+
 types = {
     Hinawa.FwTcode: fw_tcode_enumerators,
     Hinawa.FwRcode: fw_rcode_enumerators,
@@ -85,6 +104,7 @@ types = {
     Hinawa.FwFcpError: fw_fcp_error_enumerators,
     Hinawa.SndUnitError: snd_unit_error_enumerators,
     Hinawa.SndDiceError: snd_dice_error_enumerators,
+    Hinawa.SndEfwError: snd_efw_error_enumerators,
 }
 
 for obj, types in types.items():

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -54,10 +54,17 @@ snd_unit_type_enumerators = (
     'FIREFACE',
 )
 
+fw_node_error_enumerators = (
+    'DISCONNECTED',
+    'OPENED',
+    'NOT_OPENED',
+)
+
 types = {
     Hinawa.FwTcode: fw_tcode_enumerators,
     Hinawa.FwRcode: fw_rcode_enumerators,
     Hinawa.SndUnitType: snd_unit_type_enumerators,
+    Hinawa.FwNodeError: fw_node_error_enumerators,
 }
 
 for obj, types in types.items():

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -60,11 +60,17 @@ fw_node_error_enumerators = (
     'NOT_OPENED',
 )
 
+fw_fcp_error_enumerators = (
+    'TIMEOUT',
+    'LARGE_RESP',
+)
+
 types = {
     Hinawa.FwTcode: fw_tcode_enumerators,
     Hinawa.FwRcode: fw_rcode_enumerators,
     Hinawa.SndUnitType: snd_unit_type_enumerators,
     Hinawa.FwNodeError: fw_node_error_enumerators,
+    Hinawa.FwFcpError: fw_fcp_error_enumerators,
 }
 
 for obj, types in types.items():

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -73,6 +73,10 @@ snd_unit_error_enumerators = (
     'UNLOCKED',
 )
 
+snd_dice_error_enumerators = (
+    'TIMEOUT',
+)
+
 types = {
     Hinawa.FwTcode: fw_tcode_enumerators,
     Hinawa.FwRcode: fw_rcode_enumerators,
@@ -80,6 +84,7 @@ types = {
     Hinawa.FwNodeError: fw_node_error_enumerators,
     Hinawa.FwFcpError: fw_fcp_error_enumerators,
     Hinawa.SndUnitError: snd_unit_error_enumerators,
+    Hinawa.SndDiceError: snd_dice_error_enumerators,
 }
 
 for obj, types in types.items():


### PR DESCRIPTION
This merge request is a replacement of #61 with further enhancement.

In [guideline of GLib's GError](https://developer.gnome.org/gconf/stable/gconf-gconf-error.html), the naming scheme of GQuark for error domain is <namespace>_<module>_error_quark. Additionally, GLib enumeration should be implemented for error code and the naming scheme is <NAMESPACE>_<MODULE>_ERROR_<CODE>. GError should be instanciated just for recoverable runtime error.

Although GError is used in libhinawa for error reporting, the usage is not compliant to the above guideline. This commit enhances for it.

Fortunately, accessor methods to each instance of GQuark are not public, therefore it's possible to improve without any regressions.