### PR TITLE
fw_node/snd_unit: add failed errors

### DIFF
--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -200,9 +200,8 @@ HinawaFwFcp *hinawa_fw_fcp_new(void)
  * @resp_frame_size: The size of array for response in byte unit. The value of
  *		     this argument should point to the numerical number and
  *		     mutable.
- * @exception: A #GError. Error can be generated with four domains; #g_file_error_quark(),
- *	       #hinawa_fw_node_error_quark(), #hinawa_fw_req_error_quark(), and
- *	       #hinawa_fw_fcp_error_quark().
+ * @exception: A #GError. Error can be generated with four domains; #hinawa_fw_node_error_quark(),
+ *	       #hinawa_fw_req_error_quark(), and #hinawa_fw_fcp_error_quark().
  *
  * Execute FCP transaction.
  * Since: 1.4.

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -160,8 +160,8 @@ HinawaFwReq *hinawa_fw_req_new(void)
  * @frame_size: The size of array in byte unit. The value of this argument
  *		should point to the numerical number and mutable for read and
  *		lock transaction.
- * @exception: A #GError. Error can be generated with three domains; #g_file_error_quark(),
- *	       #hinawa_fw_node_error_quark(), and #hinawa_fw_req_error_quark().
+ * @exception: A #GError. Error can be generated with two domains; #hinawa_fw_node_error_quark(),
+ *	       and #hinawa_fw_req_error_quark().
  *
  * Execute transactions to the given node according to given code.
  * Since: 1.4.

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -136,8 +136,7 @@ HinawaFwResp *hinawa_fw_resp_new(void)
  * @node: A #HinawaFwNode.
  * @addr: A start address to listen to in host controller.
  * @width: The byte width of address to listen to host controller.
- * @exception: A #GError. Error can be generated with two domains; #g_file_error_quark() and
- *	       #hinawa_fw_node_error_quark().
+ * @exception: A #GError. Error can be generated with domain of #hinawa_fw_node_error_quark().
  *
  * Start to listen to a range of address in host controller which connects to
  * the node.

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -144,6 +144,7 @@ typedef enum {
  * @HINAWA_SND_UNIT_ERROR_LOCKED:	The hwdep device is already locked for kernel packet streaming.
  * @HINAWA_SND_UNIT_ERROR_UNLOCKED:	The hwdep device is not locked for kernel packet streaming yet.
  * @HINAWA_SND_UNIT_ERROR_WRONG_CLASS:	The hwdep device is not for the unit expected by the class.
+ * @HINAWA_SND_UNIT_ERROR_FAILED:	The system call fails.
  *
  * A set of error code for GError with domain of #HinawaSndUnitError.
  */
@@ -154,6 +155,7 @@ typedef enum {
 	HINAWA_SND_UNIT_ERROR_LOCKED,
 	HINAWA_SND_UNIT_ERROR_UNLOCKED,
 	HINAWA_SND_UNIT_ERROR_WRONG_CLASS,
+	HINAWA_SND_UNIT_ERROR_FAILED,
 } HinawaSndUnitError;
 
 /**

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -137,6 +137,7 @@ typedef enum {
 /**
  * HinawaSndUnitError:
  * @HINAWA_SND_UNIT_ERROR_DISCONNECTED:	The hwdep device associated to the instance is disconnected.
+ * @HINAWA_SND_UNIT_ERROR_USED:		The hedep device is already in use.
  * @HINAWA_SND_UNIT_ERROR_OPENED:	The instance is already associated to unit by opening hwdep
  *					character device.
  * @HINAWA_SND_UNIT_ERROR_NOT_OPENED:	The instance is not associated to unit yet by opening hwdep
@@ -150,6 +151,7 @@ typedef enum {
  */
 typedef enum {
 	HINAWA_SND_UNIT_ERROR_DISCONNECTED,
+	HINAWA_SND_UNIT_ERROR_USED,
 	HINAWA_SND_UNIT_ERROR_OPENED,
 	HINAWA_SND_UNIT_ERROR_NOT_OPENED,
 	HINAWA_SND_UNIT_ERROR_LOCKED,

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -113,6 +113,7 @@ typedef enum {
  *					firewire character device.
  * @HINAWA_FW_NODE_ERROR_NOT_OPENED:	The instance is not associated to node by opening
  *					firewire character device.
+ * @HINAWA_FW_NODE_ERROR_FAILED:	The system call fails.
  *
  * A set of error code for GError with domain which equals to #hinawa_fw_node_error_quark().
  */
@@ -120,6 +121,7 @@ typedef enum {
 	HINAWA_FW_NODE_ERROR_DISCONNECTED,
 	HINAWA_FW_NODE_ERROR_OPENED,
 	HINAWA_FW_NODE_ERROR_NOT_OPENED,
+	HINAWA_FW_NODE_ERROR_FAILED,
 } HinawaFwNodeError;
 
 /**

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -171,7 +171,7 @@ typedef enum {
  * @HINAWA_SND_EFW_ERROR_COMM_ERR:		The transaction fails due to communication error.
  * @HINAWA_SND_EFW_ERROR_BAD_QUAD_COUNT:	The number of quadlets in transaction is invalid.
  * @HINAWA_SND_EFW_ERROR_UNSUPPORTED:		The request is not supported.
- * @HINAWA_SND_EFW_ERROR_1394_TIMEOUT:		The transaction is canceled due to response timeout.
+ * @HINAWA_SND_EFW_ERROR_TIMEOUT:		The transaction is canceled due to response timeout.
  * @HINAWA_SND_EFW_ERROR_DSP_TIMEOUT:		The operation for DSP did not finish within timeout.
  * @HINAWA_SND_EFW_ERROR_BAD_RATE:		The request includes invalid value for sampling frequency.
  * @HINAWA_SND_EFW_ERROR_BAD_CLOCK:		The request includes invalid value for source of clock.

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -140,9 +140,8 @@ void hinawa_snd_dice_open(HinawaSndDice *self, gchar *path, GError **exception)
  *	   data to transmit.
  * @frame_count: The number of quadlets in the frame.
  * @bit_flag: bit flag to wait
- * @exception: A #GError. Error can be generated with four domains; #g_file_error_quark(),
- *	       #hinawa_fw_node_error_quark(), #hinawa_fw_req_error_quark(), and
- *	       #hinawa_snd_dice_error_quark().
+ * @exception: A #GError. Error can be generated with three domains; #hinawa_fw_node_error_quark(),
+ *	       #hinawa_fw_req_error_quark(), and #hinawa_snd_dice_error_quark().
  *
  * Execute write transactions to the given address, then wait and check
  * notification.

--- a/src/snd_efw.c
+++ b/src/snd_efw.c
@@ -133,8 +133,8 @@ void hinawa_snd_efw_open(HinawaSndEfw *self, gchar *path, GError **exception)
  *	    argument should point to the pointer to the array and immutable.
  *	    The content of array is mutable for parameters in response.
  * @param_count: The number of quadlets in the params array.
- * @exception: A #GError. Error can be generated with three domains; #g_file_error_quark(),
- *	       #hinawa_snd_unit_error_quark(), and #hinawa_snd_efw_error_quark().
+ * @exception: A #GError. Error can be generated with three domains; #hinawa_snd_unit_error_quark(),
+ *	       and #hinawa_snd_efw_error_quark().
  *
  * Execute transaction according to Echo Fireworks Transaction protocol.
  *

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -91,7 +91,7 @@ void hinawa_snd_tscm_open(HinawaSndTscm *self, gchar *path, GError **exception)
 /**
  * hinawa_snd_tscm_get_state:
  * @self: A #HinawaSndTscm
- * @exception: A #GError
+ * @exception: A #GError. Error can be generated with domain of #hinawa_snd_unit_error_quark().
  *
  * Get the latest states of target device.
  *

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -34,6 +34,7 @@ G_DEFINE_QUARK(hinawa-snd-unit-error-quark, hinawa_snd_unit_error)
 
 static const char *const err_msgs[] = {
 	[HINAWA_SND_UNIT_ERROR_DISCONNECTED] = "The associated hwdep device is not available",
+	[HINAWA_SND_UNIT_ERROR_USED] = "The hedep device is already in use",
 	[HINAWA_SND_UNIT_ERROR_OPENED] = "The instance is already associated to unit",
 	[HINAWA_SND_UNIT_ERROR_NOT_OPENED] = "The instance is not associated to unit yet",
 	[HINAWA_SND_UNIT_ERROR_LOCKED] = "The associated hwdep device is already locked or kernel packet streaming runs",
@@ -253,6 +254,8 @@ void hinawa_snd_unit_open(HinawaSndUnit *self, gchar *path, GError **exception)
 	if (priv->fd < 0) {
 		if (errno == ENODEV) {
 			generate_local_error(exception, HINAWA_SND_UNIT_ERROR_DISCONNECTED);
+		} else if (errno == EBUSY) {
+			generate_local_error(exception, HINAWA_SND_UNIT_ERROR_USED);
 		} else {
 			GFileError code = g_file_error_from_errno(errno);
 

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -72,6 +72,7 @@ snd_unit_error_enumerators = (
     'NOT_OPENED',
     'LOCKED',
     'UNLOCKED',
+    'FAILED',
 )
 
 snd_dice_error_enumerators = (

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -68,6 +68,7 @@ fw_fcp_error_enumerators = (
 
 snd_unit_error_enumerators = (
     'DISCONNECTED',
+    'USED',
     'OPENED',
     'NOT_OPENED',
     'LOCKED',

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -58,6 +58,7 @@ fw_node_error_enumerators = (
     'DISCONNECTED',
     'OPENED',
     'NOT_OPENED',
+    'FAILED',
 )
 
 fw_fcp_error_enumerators = (


### PR DESCRIPTION
In [guideline of GLib's GError](https://developer.gnome.org/gconf/stable/gconf-gconf-error.html), it's better to add `failed` entry into enumerations for error to report unrecoverable error. In libhinawa, errors from system call is the kind.

This commit adds the `failed` errors into fw_node/snd_unit, with some fixes.