### PR TITLE
[PATCH 00/11] add missing annotations and correct existent annotations

### DIFF
--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -27,6 +27,8 @@
  *
  * Return the GQuark for error domain of GError which has code in #HinawaFwFcpError.
  *
+ * Since: 2.1
+ *
  * Returns: A #GQuark.
  */
 G_DEFINE_QUARK(hinawa-fw-fcp-error-quark, hinawa_fw_fcp_error)
@@ -144,6 +146,12 @@ static void hinawa_fw_fcp_class_init(HinawaFwFcpClass *klass)
 	gobject_class->set_property = fw_fcp_set_property;
 	gobject_class->finalize = fw_fcp_finalize;
 
+	/**
+	 * HinawaFwFcp:timeout:
+	 *
+	 * Since 1.4
+	 * Deprecated: 2.1: Use timeout_ms parameter of #hinawa_fw_fcp_avc_transaction().
+	 */
 	fw_fcp_props[FW_FCP_PROP_TYPE_TIMEOUT] =
 		g_param_spec_uint("timeout", "timeout",
 				  "An elapse to expire waiting for response "
@@ -151,6 +159,12 @@ static void hinawa_fw_fcp_class_init(HinawaFwFcpClass *klass)
 				  10, G_MAXUINT,
 				  200,
 				  G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
+
+	/**
+	 * HinawaFwFcp:is-bound:
+	 *
+	 * Since: 2.0
+	 */
 	fw_fcp_props[FW_FCP_PROP_TYPE_IS_BOUND] =
 		g_param_spec_boolean("is-bound", "is-bound",
 				     "Whether this protocol is bound to any "
@@ -173,6 +187,8 @@ static void hinawa_fw_fcp_class_init(HinawaFwFcpClass *klass)
          * protocol, and the process successfully reads the content of packet from ALSA
          * Fireworks driver, the #HinawaFwFcp::responded signal handler is called with parameters
 	 * of the response.
+	 *
+	 * Since: 2.1
          */
         fw_fcp_sigs[FW_FCP_SIG_TYPE_RESPONDED] =
                 g_signal_new("responded",
@@ -416,6 +432,8 @@ static HinawaFwRcode handle_requested2_signal(HinawaFwResp *resp, HinawaFwTcode 
  * @exception: A #GError. Error can be generated with domain of #hinawa_fw_resp_error_quark().
  *
  * Start to listen to FCP responses.
+ *
+ * Since: 1.4
  */
 void hinawa_fw_fcp_bind(HinawaFwFcp *self, HinawaFwNode *node,
 			GError **exception)

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -61,6 +61,8 @@ struct _HinawaFwFcpClass {
          * protocol, and the process successfully reads the content of packet from ALSA
          * Fireworks driver, the #HinawaFwFcpClass::responded signal handler is called with
 	 * parameters of the response.
+	 *
+	 * Since: 2.1
          */
 	void (*responded)(HinawaFwFcp *self, const guint8 *frame, guint frame_size);
 };

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -48,6 +48,8 @@ G_DEFINE_TYPE_WITH_PRIVATE(HinawaFwNode, hinawa_fw_node, G_TYPE_OBJECT)
  *
  * Return the GQuark for error domain of GError which has code in #HinawaFwNodeError.
  *
+ * Since: 2.1
+ *
  * Returns: A #GQuark.
  */
 G_DEFINE_QUARK(hinawa-fw-node-error-quark, hinawa_fw_node_error)
@@ -150,39 +152,76 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 	gobject_class->finalize = fw_node_finalize;
 	gobject_class->get_property = fw_node_get_property;
 
+	/**
+	 * HinawaFwNode:node-id:
+	 *
+	 * Since: 1.4
+	 */
 	fw_node_props[FW_NODE_PROP_TYPE_NODE_ID] =
 		g_param_spec_uint("node-id", "node-id",
-				  "Node-ID of this node at this generation.",
+				  "Node ID of node associated to instance of object at current "
+				  "generation of bus topology. This parameter is effective after "
+				  "the association.",
 				  0, G_MAXUINT32, 0,
 				  G_PARAM_READABLE);
+
+	/**
+	 * HinawaFwNode:local-node-id:
+	 *
+	 * Since: 1.4
+	 */
 	fw_node_props[FW_NODE_PROP_TYPE_LOCAL_NODE_ID] =
 		g_param_spec_uint("local-node-id", "local-node-id",
-				  "Node-ID for a node which this node use to "
-				  "communicate to the other nodes on the bus "
-				  "at this generation.",
+				  "Node ID of node which application uses to communicate to node "
+				  "associated to instance of object at current generation of bus "
+				  "topology. In general, it is for OHCI 1394 host controller.",
 				  0, G_MAXUINT32, 0,
 				  G_PARAM_READABLE);
+
+	/**
+	 * HinawaFwNode:bus-manager-node-id:
+	 *
+	 * Since: 1.4
+	 */
 	fw_node_props[FW_NODE_PROP_TYPE_BUS_MANAGER_NODE_ID] =
 		g_param_spec_uint("bus-manager-node-id", "bus-manager-node-id",
-				  "Node-ID for bus manager on the bus at this "
-				  "generation.",
+				  "Node ID of node which plays role of bus manager at current "
+				  "generation of bus topology.",
 				  0, G_MAXUINT32, 0,
 				  G_PARAM_READABLE);
+
+	/**
+	 * HinawaFwNode:ir-manager-node-id:
+	 *
+	 * Since: 1.4
+	 */
 	fw_node_props[FW_NODE_PROP_TYPE_IR_MANAGER_NODE_ID] =
 		g_param_spec_uint("ir-manager-node-id", "ir-manager-node-id",
-				  "Node-ID for isochronous resource manager "
-				  "on the bus at this generation",
+				  "Node ID of node which plays role of isochronous resource "
+				  "manager at current generation of bus topology.",
 				  0, G_MAXUINT32, 0,
 				  G_PARAM_READABLE);
+
+	/**
+	 * HinawaFwNode:root-node-id:
+	 *
+	 * Since: 1.4
+	 */
 	fw_node_props[FW_NODE_PROP_TYPE_ROOT_NODE_ID] =
 		g_param_spec_uint("root-node-id", "root-node-id",
-				  "Node-ID for root of bus topology at this "
-				  "generation.",
+				  "Node ID of root node in bus topology at current generation of "
+				  "the bus topology.",
 				  0, G_MAXUINT32, 0,
 				  G_PARAM_READABLE);
+
+	/**
+	 * HinawaFwNode:generation:
+	 *
+	 * Since: 1.4
+	 */
 	fw_node_props[FW_NODE_PROP_TYPE_GENERATION] =
 		g_param_spec_uint("generation", "generation",
-				  "current level of generation on this bus.",
+				  "Current generation of bus topology",
 				  0, G_MAXUINT32, 0,
 				  G_PARAM_READABLE);
 
@@ -198,7 +237,7 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 	 * Handlers can read current generation in the bus via 'generation'
 	 * property.
 	 *
-	 * Since: 1.4.
+	 * Since: 1.4
 	 */
 	fw_node_sigs[FW_NODE_SIG_TYPE_BUS_UPDATE] =
 		g_signal_new("bus-update",
@@ -216,7 +255,7 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 	 * When phicical FireWire devices are disconnected from IEEE 1394 bus,
 	 * the #HinawaFwNode::disconnected signal is generated.
 	 *
-	 * Since: 1.4.
+	 * Since: 1.4
 	 */
 	fw_node_sigs[FW_NODE_SIG_TYPE_DISCONNECTED] =
 		g_signal_new("disconnected",

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -24,6 +24,8 @@
  *
  * Return the GQuark for error domain of GError which has code in #HinawaFwRcode.
  *
+ * Since: 2.1
+ *
  * Returns: A #GQuark.
  */
 G_DEFINE_QUARK(hinawa-fw-req-error-quark, hinawa_fw_req_error)
@@ -35,7 +37,6 @@ enum fw_req_prop_type {
 };
 static GParamSpec *fw_req_props[FW_REQ_PROP_TYPE_COUNT] = { NULL, };
 
-/* NOTE: This object has no properties and no signals. */
 struct _HinawaFwReqPrivate {
 	guint timeout;
 };
@@ -102,6 +103,12 @@ static void hinawa_fw_req_class_init(HinawaFwReqClass *klass)
 	gobject_class->get_property = fw_req_get_property;
 	gobject_class->set_property = fw_req_set_property;
 
+	/**
+	 * HinawaFwReq:timeout:
+	 *
+	 * Since: 1.4
+	 * Deprecated: 2.1: Use timeout_ms parameter of #hinawa_fw_req_transaction_sync().
+	 */
 	fw_req_props[FW_REQ_PROP_TYPE_TIMEOUT] =
 		g_param_spec_uint("timeout", "timeout",
 				  "An elapse to expire waiting for response by ms unit.",
@@ -124,6 +131,8 @@ static void hinawa_fw_req_class_init(HinawaFwReqClass *klass)
 	 * When the unit transfers asynchronous packet as response subaction for the transaction,
 	 * and the process successfully reads the content of packet from Linux firewire subsystem,
 	 * the #HinawaFwReq::responded signal handler is called.
+	 *
+	 * Since: 2.1
 	 */
 	fw_req_sigs[FW_REQ_SIG_TYPE_RESPONDED] =
 		g_signal_new("responded",
@@ -396,7 +405,8 @@ void hinawa_fw_req_transaction_sync(HinawaFwReq *self, HinawaFwNode *node,
  * Execute request subaction of transaction to the given node according to given code, then wait
  * for response subaction within #HinawaFwReq:timeout.
  *
- * Since: 1.4.
+ * Since: 1.4
+ * Deprecated: 2.1: Use #hinawa_fw_req_transaction_sync(), instead.
  */
 void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 			       HinawaFwTcode tcode, guint64 addr, gsize length,

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -60,6 +60,8 @@ struct _HinawaFwReqClass {
 	 * When the unit transfers asynchronous packet as response subaction for the transaction,
 	 * and the process successfully reads the content of packet from Linux firewire subsystem,
 	 * the #HinawaFwReqClass::responded handler is called.
+	 *
+	 * Since: 2.1
 	 */
 	void (*responded)(HinawaFwReq *self, HinawaFwRcode rcode,
 			  const guint8 *frame, guint frame_size);

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -24,6 +24,8 @@
  *
  * Return the GQuark for error domain of GError which has code in #HinawaFwRespError.
  *
+ * Since: 2.2
+ *
  * Returns: A #GQuark.
  */
 G_DEFINE_QUARK(hinawa-fw-resp-error-quark, hinawa_fw_resp_error)
@@ -100,6 +102,11 @@ static void hinawa_fw_resp_class_init(HinawaFwRespClass *klass)
 	gobject_class->get_property = fw_resp_get_property;
 	gobject_class->finalize = fw_resp_finalize;
 
+	/**
+	 * HinawaFwResp:is-reserved:
+	 *
+	 * Since: 2.0
+	 */
 	fw_resp_props[FW_RESP_PROP_TYPE_IS_RESERVED] =
 		g_param_spec_boolean("is-reserved", "is-reserved",
 				     "Whether a range of address is reserved "
@@ -126,6 +133,7 @@ static void hinawa_fw_resp_class_init(HinawaFwRespClass *klass)
 	 * Returns: One of #HinawaRcode enumerators corresponding to rcodes defined in IEEE 1394
 	 * specification.
 	 *
+	 * Since: 0.3
 	 * Deprecated: 2.2: Use #HinawaFwResp::requested2, instead.
 	 */
 	fw_resp_sigs[FW_RESP_SIG_TYPE_REQ] =
@@ -157,6 +165,7 @@ static void hinawa_fw_resp_class_init(HinawaFwRespClass *klass)
 	 *
 	 * Returns: One of #HinawaRcode enumerators corresponding to rcodes defined in IEEE 1394
 	 *	    specification.
+	 * Since: 2.2
 	 */
 	fw_resp_sigs[FW_RESP_SIG_TYPE_REQ2] =
 		g_signal_new("requested2",
@@ -291,6 +300,7 @@ void hinawa_fw_resp_release(HinawaFwResp *self)
  *
  * Retrieve byte frame to be requested.
  *
+ * Since: 2.0
  * Deprecated: 2.2: handler for #HinawaFwResp::requested2 signal can receive the frame in its
  *		    argument.
  */
@@ -319,6 +329,8 @@ void hinawa_fw_resp_get_req_frame(HinawaFwResp *self, const guint8 **frame,
  * @length: The length of bytes for the frame.
  *
  * Register byte frame as response.
+ *
+ * Since: 2.0
  */
 void hinawa_fw_resp_set_resp_frame(HinawaFwResp *self, guint8 *frame,
 				   gsize length)

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -88,6 +88,8 @@ struct _HinawaFwRespClass {
 	 *
 	 * Returns: One of #HinawaRcode enumerators corresponding to rcodes defined in IEEE 1394
 	 *	    specification.
+	 *
+	 * Since: 2.2
 	 */
 	HinawaFwRcode (*requested2)(HinawaFwResp *self, HinawaFwTcode tcode, guint64 offset,
 				    guint32 src, guint32 dst, guint32 card, guint32 generation,

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -29,6 +29,7 @@
  *
  * A representation for tcode of asynchronous transaction on IEEE 1394 bus.
  *
+ * Since: 1.0
  */
 typedef enum {
 	HINAWA_FW_TCODE_WRITE_QUADLET_REQUEST	= TCODE_WRITE_QUADLET_REQUEST,
@@ -67,6 +68,7 @@ typedef enum {
  *
  * A representation for rcode of asynchronous transaction on IEEE 1394 bus.
  *
+ * Since: 1.0
  */
 typedef enum {
 	HINAWA_FW_RCODE_COMPLETE	= RCODE_COMPLETE,
@@ -94,6 +96,8 @@ typedef enum {
  * @HINAWA_SND_UNIT_TYPE_FIREFACE:	The type of RME Fireface series.
  *
  * A representation of type for sound unit defined by Linux sound subsystem.
+ *
+ * Since: 1.0
  */
 typedef enum {
 	HINAWA_SND_UNIT_TYPE_DICE = 1,
@@ -116,6 +120,8 @@ typedef enum {
  * @HINAWA_FW_NODE_ERROR_FAILED:	The system call fails.
  *
  * A set of error code for GError with domain which equals to #hinawa_fw_node_error_quark().
+ *
+ * Since: 2.1
  */
 typedef enum {
 	HINAWA_FW_NODE_ERROR_DISCONNECTED,
@@ -131,6 +137,8 @@ typedef enum {
  * @HINAWA_FW_RESP_ERROR_ADDR_SPACE_USED:	The address space is used exclusively.
  *
  * A set of error code for GError with domain which equals to #hinawa_fw_resp_error_quark().
+ *
+ * Since: 2.2
  */
 typedef enum {
 	HINAWA_FW_RESP_ERROR_FAILED = 0,
@@ -144,6 +152,8 @@ typedef enum {
  * @HINAWA_FW_FCP_ERROR_LARGE_RESP:	The size of response is larger than expected.
  *
  * A set of error code for GError with domain which equals to #hinawa_fw_fcp_error_quark().
+ *
+ * Since: 2.1
  */
 typedef enum {
 	HINAWA_FW_FCP_ERROR_TIMEOUT,
@@ -164,6 +174,8 @@ typedef enum {
  * @HINAWA_SND_UNIT_ERROR_FAILED:	The system call fails.
  *
  * A set of error code for GError with domain which equals to #hinawa_snd_unit_error_quark().
+ *
+ * Since: 2.1
  */
 typedef enum {
 	HINAWA_SND_UNIT_ERROR_DISCONNECTED,
@@ -181,6 +193,8 @@ typedef enum {
  * @HINAWA_SND_DICE_ERROR_TIMEOUT:	The transaction is canceled due to response timeout.
  *
  * A set of error code for GError with domain which equals to #hinawa_snd_dice_error_quark().
+ *
+ * Since: 2.1
  */
 typedef enum {
 	HINAWA_SND_DICE_ERROR_TIMEOUT,
@@ -207,6 +221,8 @@ typedef enum {
  * @HINAWA_SND_EFW_STATUS_LARGE_RESP:		The size of response is larger than expected.
  *
  * A set of status code for Echo Audio Fireworks Transaction.
+ *
+ * Since: 2.1
  */
 typedef enum {
 	HINAWA_SND_EFW_STATUS_OK		= 0,

--- a/src/snd_dg00x.c
+++ b/src/snd_dg00x.c
@@ -32,6 +32,8 @@ static void hinawa_snd_dg00x_class_init(HinawaSndDg00xClass *klass)
 	 *
 	 * When Dg00x models transfer notification, the #HinawaSndDg00x::message signal is
 	 * generated.
+	 *
+	 * Since: 0.7
 	 */
 	dg00x_sigs[DG00X_SIG_TYPE_MESSAGE] =
 		g_signal_new("message",
@@ -69,6 +71,8 @@ HinawaSndDg00x *hinawa_snd_dg00x_new(void)
  *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Dg00x  devices.
+ *
+ * Since: 0.7
  */
 void hinawa_snd_dg00x_open(HinawaSndDg00x *self, gchar *path, GError **exception)
 {

--- a/src/snd_dg00x.h
+++ b/src/snd_dg00x.h
@@ -48,6 +48,8 @@ struct _HinawaSndDg00xClass {
 	 *
 	 * When Dg00x models transfer notification, the #HinawaSndDg00xClass::message handler is
 	 * called.
+	 *
+	 * Since: 1.2
 	 */
 	void (*message)(HinawaSndDg00x *self, guint32 message);
 };

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -19,6 +19,8 @@
  *
  * Return the GQuark for error domain of GError which has code in #HinawaSndDiceError.
  *
+ * Since: 2.1
+ *
  * Returns: A #GQuark.
  */
 G_DEFINE_QUARK(hinawa-snd-dice-error-quark, hinawa_snd_dice_error)
@@ -74,6 +76,8 @@ static void hinawa_snd_dice_class_init(HinawaSndDiceClass *klass)
 	 *
 	 * When Dice models transfer notification, the #HinawaSndDice::notified signal is
 	 * generated.
+	 *
+	 * Since: 0.3
 	 */
 	dice_sigs[DICE_SIG_TYPE_NOTIFIED] =
 		g_signal_new("notified",
@@ -111,6 +115,8 @@ HinawaSndDice *hinawa_snd_dice_new(void)
  *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Dice  devices.
+ *
+ * Since: 0.4
  */
 void hinawa_snd_dice_open(HinawaSndDice *self, gchar *path, GError **exception)
 {

--- a/src/snd_dice.h
+++ b/src/snd_dice.h
@@ -55,6 +55,8 @@ struct _HinawaSndDiceClass {
 	 *
 	 * When Dice models transfer notification, the #HinawaSndDiceClass::notified handler is
 	 * called.
+	 *
+	 * Since: 1.2
 	 */
 	void (*notified)(HinawaSndDice *self, guint message);
 };

--- a/src/snd_efw.c
+++ b/src/snd_efw.c
@@ -20,6 +20,8 @@
  *
  * Return the GQuark for error domain of GError which has code in #HinawaSndEfwStatus.
  *
+ * Since: 2.1
+ *
  * Returns: A #GQuark.
  */
 G_DEFINE_QUARK(hinawa-snd-efw-error-quark, hinawa_snd_efw_error)
@@ -79,6 +81,8 @@ static void hinawa_snd_efw_class_init(HinawaSndEfwClass *klass)
 	 * protocol, and the process successfully reads the content of response from ALSA
 	 * Fireworks driver, the #HinawaSndEfw::responded signal handler is called with parameters
 	 * of the response.
+	 *
+	 * Since: 2.1
 	 */
 	efw_sigs[EFW_SIG_TYPE_RESPONDED] =
 		g_signal_new("responded",
@@ -117,6 +121,8 @@ HinawaSndEfw *hinawa_snd_efw_new(void)
  *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Fireworks devices.
+ *
+ * Since: 0.3
  */
 void hinawa_snd_efw_open(HinawaSndEfw *self, gchar *path, GError **exception)
 {

--- a/src/snd_efw.h
+++ b/src/snd_efw.h
@@ -63,6 +63,8 @@ struct _HinawaSndEfwClass {
 	 * protocol, and the process successfully reads the content of response from ALSA
 	 * Fireworks driver, the #HinawaSndEfwClass::responded signal handler is called with parameters
 	 * of the response.
+	 *
+	 * Since: 2.1
 	 */
 	void (*responded)(HinawaSndEfw *self, HinawaSndEfwStatus status, guint seqnum,
 			  guint category, guint command, const guint32 *frame, guint frame_size);

--- a/src/snd_motu.c
+++ b/src/snd_motu.c
@@ -35,6 +35,8 @@ static void hinawa_snd_motu_class_init(HinawaSndMotuClass *klass)
 	 *
 	 * When Motu models transfer notification, the #HinawaSndMotu::notified signal is
 	 * generated.
+	 *
+	 * Since: 0.8
 	 */
 	motu_sigs[MOTU_SIG_TYPE_NOTIFIED] =
 		g_signal_new("notified",
@@ -72,6 +74,8 @@ HinawaSndMotu *hinawa_snd_motu_new(void)
  *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Motu devices.
+ *
+ * Since: 0.8
  */
 void hinawa_snd_motu_open(HinawaSndMotu *self, gchar *path, GError **exception)
 {

--- a/src/snd_motu.h
+++ b/src/snd_motu.h
@@ -51,6 +51,8 @@ struct _HinawaSndMotuClass {
 	 *
 	 * When Motu models transfer notification, the #HinawaSndMotuClass::notified handler is
 	 * called.
+	 *
+	 * Since: 1.2
 	 */
 	void (*notified)(HinawaSndMotu *self, guint message);
 };

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -40,6 +40,8 @@ static void hinawa_snd_tscm_class_init(HinawaSndTscmClass *klass)
 	 *
 	 * When TASCAM FireWire unit transfer control message, the #HinawaSndTscm::control
 	 * signal is emitted.
+	 *
+	 * Since: 1.1
 	 */
 	tscm_sigs[TSCM_SIG_TYPE_CTL] =
 		g_signal_new("control",
@@ -78,6 +80,8 @@ HinawaSndTscm *hinawa_snd_tscm_new(void)
  *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for Dg00x  devices.
+ *
+ * Since: 1.1
  */
 void hinawa_snd_tscm_open(HinawaSndTscm *self, gchar *path, GError **exception)
 {
@@ -95,9 +99,9 @@ void hinawa_snd_tscm_open(HinawaSndTscm *self, gchar *path, GError **exception)
  *
  * Get the latest states of target device.
  *
- * Returns: (element-type guint32) (array fixed-size=64) (transfer none): state
- * 	    image.
+ * Returns: (element-type guint32) (array fixed-size=64) (transfer none): state image.
  *
+ * Since: 1.1
  */
 const guint32 *hinawa_snd_tscm_get_state(HinawaSndTscm *self,
 					 GError **exception)

--- a/src/snd_tscm.h
+++ b/src/snd_tscm.h
@@ -53,6 +53,8 @@ struct _HinawaSndTscmClass {
 	 *
 	 * When TASCAM FireWire unit transfer control message, the #HinawaSndTscmClass::control
 	 * handler is emitted.
+	 *
+	 * Since: 1.2
 	 */
 	void (*control)(HinawaSndTscm *self, guint index, guint before,
 			guint after);

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -28,6 +28,8 @@
  *
  * Return the GQuark for error domain of GError which has code in #HinawaSndUnitError.
  *
+ * Since: 2.1
+ *
  * Returns: A #GQuark.
  */
 G_DEFINE_QUARK(hinawa-snd-unit-error-quark, hinawa_snd_unit_error)
@@ -136,28 +138,58 @@ static void hinawa_snd_unit_class_init(HinawaSndUnitClass *klass)
 	gobject_class->get_property = snd_unit_get_property;
 	gobject_class->finalize = snd_unit_finalize;
 
+	/**
+	 * HinawaSndUnit:type:
+	 *
+	 * Since: 1.0
+	 */
 	snd_unit_props[SND_UNIT_PROP_TYPE_FW_TYPE] =
 		g_param_spec_enum("type", "type",
 				  "The value of HinawaSndUnitType enumerators",
 				  HINAWA_TYPE_SND_UNIT_TYPE,
 				  HINAWA_SND_UNIT_TYPE_DICE,
 				  G_PARAM_READABLE);
+
+	/**
+	 * HinawaSndUnit:card:
+	 *
+	 * Since: 2.0
+	 */
 	snd_unit_props[SND_UNIT_PROP_TYPE_CARD_ID] =
 		g_param_spec_uint("card", "card",
-				  "The numerical ID for ALSA sound card",
+				  "The numeric ID for ALSA sound card",
 				  0, G_MAXUINT,
 				  0,
 				  G_PARAM_READABLE);
+
+	/**
+	 * HinawaSndUnit:device:
+	 *
+	 *
+	 * Since: 0.3
+	 */
 	snd_unit_props[SND_UNIT_PROP_TYPE_DEVICE] =
 		g_param_spec_string("device", "device",
 				    "A name of special file as FireWire unit.",
 				    NULL,
 				    G_PARAM_READABLE);
+
+	/**
+	 * HinawaSndUnit:streaming:
+	 *
+	 * Since: 0.4
+	 */
 	snd_unit_props[SND_UNIT_PROP_TYPE_STREAMING] =
 		g_param_spec_boolean("streaming", "streaming",
 				     "Whether this device is streaming or not",
 				     FALSE,
 				     G_PARAM_READABLE);
+
+	/**
+	 * HinawaSndUnit:guid:
+	 *
+	 * Since: 0.4
+	 */
 	snd_unit_props[SND_UNIT_PROP_TYPE_GUID] =
 		g_param_spec_uint64("guid", "guid",
 				    "Global unique ID for this firewire unit.",
@@ -175,6 +207,8 @@ static void hinawa_snd_unit_class_init(HinawaSndUnitClass *klass)
 	 *
 	 * When ALSA kernel-streaming status is changed, this #HinawaSndUnit::lock-status
 	 * signal is generated.
+	 *
+	 * Since: 0.3
 	 */
 	snd_unit_sigs[SND_UNIT_SIG_TYPE_LOCK_STATUS] =
 		g_signal_new("lock-status",
@@ -193,6 +227,8 @@ static void hinawa_snd_unit_class_init(HinawaSndUnitClass *klass)
 	 * or hot unplugging, this signal is emit. The owner of this object
 	 * should call g_object_free() as quickly as possible to release ALSA
 	 * hwdep character device.
+	 *
+	 * Since: 2.0
 	 */
 	snd_unit_sigs[SND_UNIT_SIG_TYPE_DISCONNECTED] =
 		g_signal_new("disconnected",
@@ -233,6 +269,8 @@ HinawaSndUnit *hinawa_snd_unit_new(void)
  *	       #hinawa_fw_node_error_quark(), and #hinawa_snd_unit_error_quark().
  *
  * Open ALSA hwdep character device and check it for FireWire sound devices.
+ *
+ * Since: 0.4
  */
 void hinawa_snd_unit_open(HinawaSndUnit *self, gchar *path, GError **exception)
 {
@@ -341,6 +379,8 @@ void hinawa_snd_unit_get_node(HinawaSndUnit *self, HinawaFwNode **node)
  * @exception: A #GError. Error can be generated with domain of #hinawa_snd_unit_error_quark().
  *
  * Disallow ALSA to start kernel-streaming.
+ *
+ * Since: 0.3
  */
 void hinawa_snd_unit_lock(HinawaSndUnit *self, GError **exception)
 {
@@ -371,6 +411,8 @@ void hinawa_snd_unit_lock(HinawaSndUnit *self, GError **exception)
  * @exception: A #GError. Error can be generated with domain of #hinawa_snd_unit_error_quark().
  *
  * Allow ALSA to start kernel-streaming.
+ *
+ * Since: 0.3
  */
 void hinawa_snd_unit_unlock(HinawaSndUnit *self, GError **exception)
 {

--- a/src/snd_unit.h
+++ b/src/snd_unit.h
@@ -55,6 +55,8 @@ struct _HinawaSndUnitClass {
 	 *
 	 * When ALSA kernel-streaming status is changed, this #HinawaSndUnitClass::lock_status
 	 * handler is called.
+	 *
+	 * Since: 1.2
 	 */
 	void (*lock_status)(HinawaSndUnit *self, gboolean state);
 
@@ -66,6 +68,8 @@ struct _HinawaSndUnitClass {
 	 * or hot unplugging, this signal is emit. The owner of this object
 	 * should call g_object_free() as quickly as possible to release ALSA
 	 * hwdep character device.
+	 *
+	 * Since: 2.0
 	 */
 	void (*disconnected)(HinawaSndUnit *self);
 };


### PR DESCRIPTION
During 7 years for development, there are missing annotations in some APIs. This patchset is to correct them.

```
Takashi Sakamoto (11):
  fw_node: add missing annotations and correct
  fw_req: add missing annotations and correct
  fw_resp: add missing annotations and correct
  fw_fcp: add missing annotations and correct
  snd_unit: add missing annotations and correct
  snd_dice: add missing annotations and correct
  snd_dg00x: add missing annotations and correct
  snd_motu: add missing annotations and correct
  snd_tscm: add missing annotations and correct
  snd_efw: add missing annotations and correct
  enum: add missing annotations and correct

 src/fw_fcp.c            | 18 ++++++++++++
 src/fw_fcp.h            |  2 ++
 src/fw_node.c           | 65 ++++++++++++++++++++++++++++++++---------
 src/fw_req.c            | 14 +++++++--
 src/fw_req.h            |  2 ++
 src/fw_resp.c           | 12 ++++++++
 src/fw_resp.h           |  2 ++
 src/hinawa_enum_types.h | 16 ++++++++++
 src/snd_dg00x.c         |  4 +++
 src/snd_dg00x.h         |  2 ++
 src/snd_dice.c          |  6 ++++
 src/snd_dice.h          |  2 ++
 src/snd_efw.c           |  6 ++++
 src/snd_efw.h           |  2 ++
 src/snd_motu.c          |  4 +++
 src/snd_motu.h          |  2 ++
 src/snd_tscm.c          |  8 +++--
 src/snd_tscm.h          |  2 ++
 src/snd_unit.c          | 44 +++++++++++++++++++++++++++-
 src/snd_unit.h          |  4 +++
 20 files changed, 199 insertions(+), 18 deletions(-)
```