### PR TITLE
[PATCH 0/2] fw_resp: add API to look up region of address and reserve range of address.

### DIFF
--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -297,7 +297,8 @@ static int update_info(HinawaFwNode *self)
 	unsigned int quads;
 	int i;
 
-	// Duplicate generation parameters in userspace.
+	// Duplicate generation parameters in userspace. The interface version 4 is used for
+	// 'struct fw_cdev_event_request2' and 'struct fw_cdev_allocate.region_end'.
 	info.version = 4;
 	info.rom = (__u64)priv->config_rom;
 	info.rom_length = MAX_CONFIG_ROM_LENGTH;

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -100,6 +100,9 @@ GType hinawa_fw_resp_get_type(void) G_GNUC_CONST;
 
 HinawaFwResp *hinawa_fw_resp_new(void);
 
+void hinawa_fw_resp_reserve_within_region(HinawaFwResp *self, HinawaFwNode *node,
+					  guint64 region_start, guint64 region_end, guint width,
+					  GError **exception);
 void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
 			    guint64 addr, guint width, GError **exception);
 void hinawa_fw_resp_release(HinawaFwResp *self);

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -124,3 +124,8 @@ HINAWA_2_2_0 {
     "hinawa_fw_resp_error_get_type";
     "hinawa_fw_resp_error_quark";
 } HINAWA_2_1_0;
+
+HINAWA_2_3_0 {
+  global:
+    "hinawa_fw_resp_reserve_within_region";
+} HINAWA_2_2_0;

--- a/tests/fw-resp
+++ b/tests/fw-resp
@@ -20,6 +20,7 @@ methods = (
     'get_req_frame',
     'set_resp_frame',
     'reserve',
+    'reserve_within_region',
     'release',
 )
 vmethods = (

--- a/tests/fw-resp
+++ b/tests/fw-resp
@@ -12,6 +12,8 @@ from gi.repository import Hinawa
 target = Hinawa.FwResp()
 props = (
     'is-reserved',
+    'offset',
+    'width',
 )
 methods = (
     'new',


### PR DESCRIPTION
Linux FireWire subsystem allows applications to reserve range of address within specified region of address in OHCI 1394 host controller. This commit adds new API for it.

```
Takashi Sakamoto (2):
  fw_resp: add properties for offset and width to express reserved range of address
  fw_resp: add API to look up region of address and reserve range of address.

 src/fw_node.c  |  3 +-
 src/fw_resp.c  | 81 +++++++++++++++++++++++++++++++++++++++++++-------
 src/fw_resp.h  |  3 ++
 src/hinawa.map |  5 ++++
 tests/fw-resp  |  3 ++
 5 files changed, 84 insertions(+), 11 deletions(-)
```