### PR TITLE
[PATCH 00/11] use utility macro to declare GObject-derived objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ Documentation
 Dependencies
 ============
 
-- Glib 2.34.0 or later
+- Glib 2.44.0 or later
 - GObject Introspection 1.32.1 or later
 - Linux kernel 3.12 or later
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 libhinawa
 =========
 
-2022/03/11
+2022/04/17
 Takashi Sakamoto
 
 Instruction
@@ -90,11 +90,10 @@ How to build
 
 ::
 
-    $ meson . build
-    $ cd build
-    $ ninja
-    $ ninja install
-    ($ ninja test)
+    $ meson (--prefix=directory-to-install) build
+    $ meson compile -C build
+    $ meson install -C build
+    ($ meson test -C build)
 
 When working with gobject-introspection, ``Hinawa-3.0.typelib`` should be
 installed in your system girepository so that ``libgirepository`` can find
@@ -109,10 +108,11 @@ How to generate document
 
 ::
 
-    $ meson -Ddoc=true . build
-    $ cd build
-    $ ninja
-    $ ninja install
+    $ meson configure (--prefix=directory-to-install) -Ddoc=true build
+    $ meson compile -C build
+    $ meson install -C build
+
+You can see documentation files under ``(directory-to-install)/share/doc/hinawa/``.
 
 Sample scripts
 ==============

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -64,11 +64,11 @@ enum avc_status {
 	AVC_STATUS_INTERIM		= 0x0f,
 };
 
-struct _HinawaFwFcpPrivate {
+typedef struct {
 	HinawaFwNode *node;
 
 	guint timeout;
-};
+} HinawaFwFcpPrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaFwFcp, hinawa_fw_fcp, HINAWA_TYPE_FW_RESP)
 
 /* This object has one property. */

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -8,39 +8,11 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_FCP	(hinawa_fw_fcp_get_type())
 
-#define HINAWA_FW_FCP(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_FW_FCP,		\
-				    HinawaFwFcp))
-#define HINAWA_IS_FW_FCP(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_FW_FCP))
-
-#define HINAWA_FW_FCP_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_FW_FCP,		\
-				 HinawaFwFcpClass))
-#define HINAWA_IS_FW_FCP_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_FW_FCP))
-#define HINAWA_FW_FCP_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_FW_FCP,		\
-				   HinawaFwFcpClass))
+G_DECLARE_DERIVABLE_TYPE(HinawaFwFcp, hinawa_fw_fcp, HINAWA, FW_FCP, HinawaFwResp);
 
 #define HINAWA_FW_FCP_ERROR	hinawa_fw_fcp_error_quark()
 
 GQuark hinawa_fw_fcp_error_quark();
-
-typedef struct _HinawaFwFcp		HinawaFwFcp;
-typedef struct _HinawaFwFcpClass	HinawaFwFcpClass;
-typedef struct _HinawaFwFcpPrivate	HinawaFwFcpPrivate;
-
-struct _HinawaFwFcp {
-	HinawaFwResp parent_instance;
-
-	HinawaFwFcpPrivate *priv;
-};
 
 struct _HinawaFwFcpClass {
 	HinawaFwRespClass parent_class;
@@ -61,8 +33,6 @@ struct _HinawaFwFcpClass {
          */
 	void (*responded)(HinawaFwFcp *self, const guint8 *frame, guint frame_size);
 };
-
-GType hinawa_fw_fcp_get_type(void) G_GNUC_CONST;
 
 HinawaFwFcp *hinawa_fw_fcp_new(void);
 

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -27,7 +27,7 @@
 #define MAX_CONFIG_ROM_SIZE	256
 #define MAX_CONFIG_ROM_LENGTH	(MAX_CONFIG_ROM_SIZE * 4)
 
-struct _HinawaFwNodePrivate {
+typedef struct {
 	int fd;
 
 	GMutex mutex;
@@ -37,8 +37,7 @@ struct _HinawaFwNodePrivate {
 
 	GList *transactions;
 	GMutex transactions_mutex;
-};
-
+} HinawaFwNodePrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaFwNode, hinawa_fw_node, G_TYPE_OBJECT)
 
 /**
@@ -461,7 +460,7 @@ static gboolean dispatch_src(GSource *gsrc, GSourceFunc cb, gpointer user_data)
 
 	common = (struct fw_cdev_event_common *)src->buf;
 
-	if (HINAWA_IS_FW_NODE(common->closure) && common->type == FW_CDEV_EVENT_BUS_RESET) {
+	if (HINAWA_IS_FW_NODE((gpointer)common->closure) && common->type == FW_CDEV_EVENT_BUS_RESET) {
 		handle_update(src->self);
 	} else if (HINAWA_IS_FW_RESP(common->closure) && common->type == FW_CDEV_EVENT_REQUEST2) {
 		hinawa_fw_resp_handle_request(HINAWA_FW_RESP(common->closure),

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -462,8 +462,8 @@ static gboolean dispatch_src(GSource *gsrc, GSourceFunc cb, gpointer user_data)
 
 	if (HINAWA_IS_FW_NODE((gpointer)common->closure) && common->type == FW_CDEV_EVENT_BUS_RESET) {
 		handle_update(src->self);
-	} else if (HINAWA_IS_FW_RESP(common->closure) && common->type == FW_CDEV_EVENT_REQUEST2) {
-		hinawa_fw_resp_handle_request(HINAWA_FW_RESP(common->closure),
+	} else if (HINAWA_IS_FW_RESP((gpointer)common->closure) && common->type == FW_CDEV_EVENT_REQUEST2) {
+		hinawa_fw_resp_handle_request(HINAWA_FW_RESP((gpointer)common->closure),
 				(struct fw_cdev_event_request2 *)common);
 	} else if (HINAWA_IS_FW_REQ((gpointer)common->closure) && common->type == FW_CDEV_EVENT_RESPONSE) {
 		struct fw_cdev_event_response *ev = (struct fw_cdev_event_response *)common;

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -465,9 +465,9 @@ static gboolean dispatch_src(GSource *gsrc, GSourceFunc cb, gpointer user_data)
 	} else if (HINAWA_IS_FW_RESP(common->closure) && common->type == FW_CDEV_EVENT_REQUEST2) {
 		hinawa_fw_resp_handle_request(HINAWA_FW_RESP(common->closure),
 				(struct fw_cdev_event_request2 *)common);
-	} else if (HINAWA_IS_FW_REQ(common->closure) && common->type == FW_CDEV_EVENT_RESPONSE) {
+	} else if (HINAWA_IS_FW_REQ((gpointer)common->closure) && common->type == FW_CDEV_EVENT_RESPONSE) {
 		struct fw_cdev_event_response *ev = (struct fw_cdev_event_response *)common;
-		HinawaFwReq *req = HINAWA_FW_REQ(ev->closure);
+		HinawaFwReq *req = HINAWA_FW_REQ((gpointer)ev->closure);
 		GList *entry;
 
 		// Don't process request invalidated in advance.

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -8,39 +8,11 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_NODE	(hinawa_fw_node_get_type())
 
-#define HINAWA_FW_NODE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_FW_NODE,	\
-				    HinawaFwNode))
-#define HINAWA_IS_FW_NODE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_FW_NODE))
-
-#define HINAWA_FW_NODE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_FW_NODE,		\
-				 HinawaFwNodeClass))
-#define HINAWA_IS_FW_NODE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_FW_NODE))
-#define HINAWA_FW_NODE_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_FW_NODE,		\
-				   HinawaFwNodeClass))
+G_DECLARE_DERIVABLE_TYPE(HinawaFwNode, hinawa_fw_node, HINAWA, FW_NODE, GObject);
 
 #define HINAWA_FW_NODE_ERROR	hinawa_fw_node_error_quark()
 
 GQuark hinawa_fw_node_error_quark();
-
-typedef struct _HinawaFwNode		HinawaFwNode;
-typedef struct _HinawaFwNodeClass	HinawaFwNodeClass;
-typedef struct _HinawaFwNodePrivate	HinawaFwNodePrivate;
-
-struct _HinawaFwNode {
-	GObject parent_instance;
-
-	HinawaFwNodePrivate *priv;
-};
 
 struct _HinawaFwNodeClass {
 	GObjectClass parent_class;
@@ -69,8 +41,6 @@ struct _HinawaFwNodeClass {
 	void (*disconnected)(HinawaFwNode *self);
 
 };
-
-GType hinawa_fw_node_get_type(void) G_GNUC_CONST;
 
 HinawaFwNode *hinawa_fw_node_new(void);
 

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -36,9 +36,9 @@ enum fw_req_prop_type {
 };
 static GParamSpec *fw_req_props[FW_REQ_PROP_TYPE_COUNT] = { NULL, };
 
-struct _HinawaFwReqPrivate {
+typedef struct {
 	guint timeout;
-};
+} HinawaFwReqPrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaFwReq, hinawa_fw_req, G_TYPE_OBJECT)
 
 static const char *const rcode_labels[] = {

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -8,39 +8,11 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_REQ	(hinawa_fw_req_get_type())
 
-#define HINAWA_FW_REQ(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_FW_REQ,		\
-				    HinawaFwReq))
-#define HINAWA_IS_FW_REQ(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_FW_REQ))
-
-#define HINAWA_FW_REQ_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_FW_REQ,		\
-				 HinawaFwReqClass))
-#define HINAWA_IS_FW_REQ_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_FW_REQ))
-#define HINAWA_FW_REQ_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_FW_REQ,		\
-				   HinawaFwReqClass))
+G_DECLARE_DERIVABLE_TYPE(HinawaFwReq, hinawa_fw_req, HINAWA, FW_REQ, GObject);
 
 #define HINAWA_FW_REQ_ERROR	hinawa_fw_req_error_quark()
 
 GQuark hinawa_fw_req_error_quark();
-
-typedef struct _HinawaFwReq		HinawaFwReq;
-typedef struct _HinawaFwReqClass	HinawaFwReqClass;
-typedef struct _HinawaFwReqPrivate	HinawaFwReqPrivate;
-
-struct _HinawaFwReq {
-	GObject parent_instance;
-
-	HinawaFwReqPrivate *priv;
-};
 
 struct _HinawaFwReqClass {
 	GObjectClass parent_class;
@@ -62,8 +34,6 @@ struct _HinawaFwReqClass {
 	void (*responded)(HinawaFwReq *self, HinawaFwRcode rcode,
 			  const guint8 *frame, guint frame_size);
 };
-
-GType hinawa_fw_req_get_type(void) G_GNUC_CONST;
 
 HinawaFwReq *hinawa_fw_req_new(void);
 

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -40,7 +40,7 @@ static const char *const err_msgs[] = {
 	g_set_error(exception, HINAWA_FW_RESP_ERROR, HINAWA_FW_RESP_ERROR_FAILED,	\
 		    format " %d(%s)", arg, errno, strerror(errno))
 
-struct _HinawaFwRespPrivate {
+typedef struct {
 	HinawaFwNode *node;
 
 	guint64 offset;
@@ -51,7 +51,7 @@ struct _HinawaFwRespPrivate {
 	gsize req_length;
 	guint8 *resp_frame;
 	gsize resp_length;
-};
+} HinawaFwRespPrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaFwResp, hinawa_fw_resp, G_TYPE_OBJECT)
 
 // This object has one property.

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -8,39 +8,11 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_RESP	(hinawa_fw_resp_get_type())
 
-#define HINAWA_FW_RESP(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_FW_RESP,	\
-				    HinawaFwResp))
-#define HINAWA_IS_FW_RESP(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_FW_RESP))
-
-#define HINAWA_FW_RESP_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_FW_RESP,		\
-				 HinawaFwRespClass))
-#define HINAWA_IS_FW_RESP_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_FW_RESP))
-#define HINAWA_FW_RESP_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_FW_RESP,		\
-				   HinawaFwRespClass))
+G_DECLARE_DERIVABLE_TYPE(HinawaFwResp, hinawa_fw_resp, HINAWA, FW_RESP, GObject);
 
 #define HINAWA_FW_RESP_ERROR	hinawa_fw_resp_error_quark()
 
 GQuark hinawa_fw_resp_error_quark();
-
-typedef struct _HinawaFwResp		HinawaFwResp;
-typedef struct _HinawaFwRespClass	HinawaFwRespClass;
-typedef struct _HinawaFwRespPrivate	HinawaFwRespPrivate;
-
-struct _HinawaFwResp {
-	GObject parent_instance;
-
-	HinawaFwRespPrivate *priv;
-};
 
 struct _HinawaFwRespClass {
 	GObjectClass parent_class;
@@ -91,8 +63,6 @@ struct _HinawaFwRespClass {
 				    guint32 src, guint32 dst, guint32 card, guint32 generation,
 				    const guint8 *frame, guint length);
 };
-
-GType hinawa_fw_resp_get_type(void) G_GNUC_CONST;
 
 HinawaFwResp *hinawa_fw_resp_new(void);
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,6 +1,6 @@
 # Depends on glib-2.0 and gobject-2.0
 gobject = dependency('gobject-2.0',
-  version: '>=2.34.0'
+  version: '>=2.44.0'
 )
 dependencies = [
   gobject,

--- a/src/snd_dg00x.h
+++ b/src/snd_dg00x.h
@@ -8,32 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_DG00X	(hinawa_snd_dg00x_get_type())
 
-#define HINAWA_SND_DG00X(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_SND_DG00X,	\
-				    HinawaSndDg00x))
-#define HINAWA_IS_SND_DG00X(obj)				\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_SND_DG00X))
-
-#define HINAWA_SND_DG00X_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_SND_DG00X,		\
-				 HinawaSndDg00xClass))
-#define HINAWA_IS_SND_DG00X_CLASS(klass)			\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_SND_DG00X))
-#define HINAWA_SND_DG00X_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_SND_DG00X,	\
-				   HinawaSndDg00xClass))
-
-typedef struct _HinawaSndDg00x		HinawaSndDg00x;
-typedef struct _HinawaSndDg00xClass	HinawaSndDg00xClass;
-
-struct _HinawaSndDg00x {
-	HinawaSndUnit parent_instance;
-};
+G_DECLARE_DERIVABLE_TYPE(HinawaSndDg00x, hinawa_snd_dg00x, HINAWA, SND_DG00X, HinawaSndUnit);
 
 struct _HinawaSndDg00xClass {
 	HinawaSndUnitClass parent_class;
@@ -50,8 +25,6 @@ struct _HinawaSndDg00xClass {
 	 */
 	void (*message)(HinawaSndDg00x *self, guint32 message);
 };
-
-GType hinawa_snd_dg00x_get_type(void) G_GNUC_CONST;
 
 HinawaSndDg00x *hinawa_snd_dg00x_new(void);
 

--- a/src/snd_dice.c
+++ b/src/snd_dice.c
@@ -38,11 +38,11 @@ struct notification_waiter {
 	gboolean awakened;
 };
 
-struct _HinawaSndDicePrivate {
+typedef struct {
 	HinawaFwReq *req;
 	GList *waiters;
 	GMutex mutex;
-};
+} HinawaSndDicePrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaSndDice, hinawa_snd_dice, HINAWA_TYPE_SND_UNIT)
 
 /* This object has one signal. */

--- a/src/snd_dice.h
+++ b/src/snd_dice.h
@@ -8,39 +8,11 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_DICE	(hinawa_snd_dice_get_type())
 
-#define HINAWA_SND_DICE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_SND_DICE,	\
-				    HinawaSndDice))
-#define HINAWA_IS_SND_DICE(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_SND_DICE))
-
-#define HINAWA_SND_DICE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_SND_DICE,		\
-				 HinawaSndDiceClass))
-#define HINAWA_IS_SND_DICE_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_SND_DICE))
-#define HINAWA_SND_DICE_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_SND_DICE,	\
-				   HinawaSndDiceClass))
+G_DECLARE_DERIVABLE_TYPE(HinawaSndDice, hinawa_snd_dice, HINAWA, SND_DICE, HinawaSndUnit);
 
 #define HINAWA_SND_DICE_ERROR	hinawa_snd_dice_error_quark()
 
 GQuark hinawa_snd_dice_error_quark();
-
-typedef struct _HinawaSndDice		HinawaSndDice;
-typedef struct _HinawaSndDiceClass	HinawaSndDiceClass;
-typedef struct _HinawaSndDicePrivate	HinawaSndDicePrivate;
-
-struct _HinawaSndDice {
-	HinawaSndUnit parent_instance;
-
-	HinawaSndDicePrivate *priv;
-};
 
 struct _HinawaSndDiceClass {
 	HinawaSndUnitClass parent_class;
@@ -57,8 +29,6 @@ struct _HinawaSndDiceClass {
 	 */
 	void (*notified)(HinawaSndDice *self, guint message);
 };
-
-GType hinawa_snd_dice_get_type(void) G_GNUC_CONST;
 
 HinawaSndDice *hinawa_snd_dice_new(void);
 

--- a/src/snd_efw.c
+++ b/src/snd_efw.c
@@ -51,10 +51,10 @@ static const char *const efw_status_names[] = {
 #define generate_local_error(exception, code)							\
 	g_set_error_literal(exception, HINAWA_SND_EFW_ERROR, code, efw_status_names[code])
 
-struct _HinawaSndEfwPrivate {
+typedef struct {
 	guint seqnum;
 	GMutex lock;
-};
+} HinawaSndEfwPrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaSndEfw, hinawa_snd_efw, HINAWA_TYPE_SND_UNIT)
 
 enum efw_sig_type {

--- a/src/snd_efw.h
+++ b/src/snd_efw.h
@@ -8,39 +8,11 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_EFW	(hinawa_snd_efw_get_type())
 
-#define HINAWA_SND_EFW(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_SND_EFW,	\
-				    HinawaSndEfw))
-#define HINAWA_IS_SND_EFW(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_SND_EFW))
-
-#define HINAWA_SND_EFW_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_SND_EFW,		\
-				 HinawaSndEfwClass))
-#define HINAWA_IS_SND_EFW_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_SND_EFW))
-#define HINAWA_SND_EFW_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_SND_EFW,		\
-				   HinawaSndEfwClass))
+G_DECLARE_DERIVABLE_TYPE(HinawaSndEfw, hinawa_snd_efw, HINAWA, SND_EFW, HinawaSndUnit);
 
 #define HINAWA_SND_EFW_ERROR	hinawa_snd_efw_error_quark()
 
 GQuark hinawa_snd_efw_error_quark();
-
-typedef struct _HinawaSndEfw		HinawaSndEfw;
-typedef struct _HinawaSndEfwClass	HinawaSndEfwClass;
-typedef struct _HinawaSndEfwPrivate	HinawaSndEfwPrivate;
-
-struct _HinawaSndEfw {
-	HinawaSndUnit parent_instance;
-
-	HinawaSndEfwPrivate *priv;
-};
 
 struct _HinawaSndEfwClass {
 	HinawaSndUnitClass parent_class;
@@ -66,8 +38,6 @@ struct _HinawaSndEfwClass {
 	void (*responded)(HinawaSndEfw *self, HinawaSndEfwStatus status, guint seqnum,
 			  guint category, guint command, const guint32 *frame, guint frame_size);
 };
-
-GType hinawa_snd_efw_get_type(void) G_GNUC_CONST;
 
 HinawaSndEfw *hinawa_snd_efw_new(void);
 

--- a/src/snd_motu.c
+++ b/src/snd_motu.c
@@ -14,9 +14,9 @@
  * Mark of the Unicorn (MOTU). This inherits #HinawaSndUnit.
  */
 
-struct _HinawaSndMotuPrivate {
+typedef struct {
 	struct snd_firewire_motu_status *status;
-};
+} HinawaSndMotuPrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaSndMotu, hinawa_snd_motu, HINAWA_TYPE_SND_UNIT)
 
 /* This object has one signal. */

--- a/src/snd_motu.h
+++ b/src/snd_motu.h
@@ -8,35 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_MOTU	(hinawa_snd_motu_get_type())
 
-#define HINAWA_SND_MOTU(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_SND_MOTU,	\
-				    HinawaSndMotu))
-#define HINAWA_IS_SND_MOTU(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_SND_MOTU))
-
-#define HINAWA_SND_MOTU_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_SND_MOTU,		\
-				 HinawaSndMotuClass))
-#define HINAWA_IS_SND_MOTU_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_SND_MOTU))
-#define HINAWA_SND_MOTU_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_SND_MOTU,	\
-				   HinawaSndMotuClass))
-
-typedef struct _HinawaSndMotu		HinawaSndMotu;
-typedef struct _HinawaSndMotuClass	HinawaSndMotuClass;
-typedef struct _HinawaSndMotuPrivate	HinawaSndMotuPrivate;
-
-struct _HinawaSndMotu {
-	HinawaSndUnit parent_instance;
-
-	HinawaSndMotuPrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE(HinawaSndMotu, hinawa_snd_motu, HINAWA, SND_MOTU, HinawaSndUnit);
 
 struct _HinawaSndMotuClass {
 	HinawaSndUnitClass parent_class;
@@ -71,8 +43,6 @@ struct _HinawaSndMotuClass {
 	 */
 	void (*register_dsp_changed)(HinawaSndMotu *self, const guint32 *events, guint length);
 };
-
-GType hinawa_snd_motu_get_type(void) G_GNUC_CONST;
 
 HinawaSndMotu *hinawa_snd_motu_new(void);
 

--- a/src/snd_tscm.c
+++ b/src/snd_tscm.c
@@ -14,10 +14,10 @@
  * inherits #HinawaSndUnit.
  */
 
-struct _HinawaSndTscmPrivate {
+typedef struct {
 	struct snd_firewire_tascam_state image;
 	guint32 state[SNDRV_FIREWIRE_TASCAM_STATE_COUNT];
-};
+} HinawaSndTscmPrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaSndTscm, hinawa_snd_tscm, HINAWA_TYPE_SND_UNIT)
 
 /* This object has one signal. */

--- a/src/snd_tscm.h
+++ b/src/snd_tscm.h
@@ -8,35 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_TSCM	(hinawa_snd_tscm_get_type())
 
-#define HINAWA_SND_TSCM(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_SND_TSCM,	\
-				    HinawaSndTscm))
-#define HINAWA_IS_SND_TSCM(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_SND_TSCM))
-
-#define HINAWA_SND_TSCM_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_SND_TSCM,		\
-				 HinawaSndTscmClass))
-#define HINAWA_IS_SND_TSCM_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_SND_TSCM))
-#define HINAWA_SND_TSCM_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_SND_TSCM,	\
-				   HinawaSndTscmClass))
-
-typedef struct _HinawaSndTscm		HinawaSndTscm;
-typedef struct _HinawaSndTscmClass	HinawaSndTscmClass;
-typedef struct _HinawaSndTscmPrivate	HinawaSndTscmPrivate;
-
-struct _HinawaSndTscm {
-	HinawaSndUnit parent_instance;
-
-	HinawaSndTscmPrivate *priv;
-};
+G_DECLARE_DERIVABLE_TYPE(HinawaSndTscm, hinawa_snd_tscm, HINAWA, SND_TSCM, HinawaSndUnit);
 
 struct _HinawaSndTscmClass {
 	HinawaSndUnitClass parent_class;
@@ -56,8 +28,6 @@ struct _HinawaSndTscmClass {
 	void (*control)(HinawaSndTscm *self, guint index, guint before,
 			guint after);
 };
-
-GType hinawa_snd_tscm_get_type(void) G_GNUC_CONST;
 
 HinawaSndTscm *hinawa_snd_tscm_new(void);
 

--- a/src/snd_unit.c
+++ b/src/snd_unit.c
@@ -53,13 +53,13 @@ static const char *const err_msgs[] = {
 	g_set_error(exception, HINAWA_SND_UNIT_ERROR, HINAWA_SND_UNIT_ERROR_FAILED,	\
 		    format " %d(%s)", arg, errno, strerror(errno))
 
-struct _HinawaSndUnitPrivate {
+typedef struct {
 	int fd;
 	struct snd_firewire_get_info info;
 	HinawaFwNode *node;
 
 	gboolean streaming;
-};
+} HinawaSndUnitPrivate;
 G_DEFINE_TYPE_WITH_PRIVATE(HinawaSndUnit, hinawa_snd_unit, G_TYPE_OBJECT)
 
 typedef struct {

--- a/src/snd_unit.h
+++ b/src/snd_unit.h
@@ -8,39 +8,11 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_UNIT	(hinawa_snd_unit_get_type())
 
-#define HINAWA_SND_UNIT(obj)					\
-	(G_TYPE_CHECK_INSTANCE_CAST((obj),			\
-				    HINAWA_TYPE_SND_UNIT,	\
-				    HinawaSndUnit))
-#define HINAWA_IS_SND_UNIT(obj)					\
-	(G_TYPE_CHECK_INSTANCE_TYPE((obj),			\
-				    HINAWA_TYPE_SND_UNIT))
-
-#define HINAWA_SND_UNIT_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_CAST((klass),			\
-				 HINAWA_TYPE_SND_UNIT,		\
-				 HinawaSndUnitClass))
-#define HINAWA_IS_SND_UNIT_CLASS(klass)				\
-	(G_TYPE_CHECK_CLASS_TYPE((klass),			\
-				 HINAWA_TYPE_SND_UNIT))
-#define HINAWA_SND_UNIT_GET_CLASS(obj)				\
-	(G_TYPE_INSTANCE_GET_CLASS((obj),			\
-				   HINAWA_TYPE_SND_UNIT,	\
-				   HinawaSndUnitClass))
+G_DECLARE_DERIVABLE_TYPE(HinawaSndUnit, hinawa_snd_unit, HINAWA, SND_UNIT, GObject);
 
 #define HINAWA_SND_UNIT_ERROR	hinawa_snd_unit_error_quark()
 
 GQuark hinawa_snd_unit_error_quark();
-
-typedef struct _HinawaSndUnit		HinawaSndUnit;
-typedef struct _HinawaSndUnitClass	HinawaSndUnitClass;
-typedef struct _HinawaSndUnitPrivate	HinawaSndUnitPrivate;
-
-struct _HinawaSndUnit {
-	GObject parent_instance;
-
-	HinawaSndUnitPrivate *priv;
-};
 
 struct _HinawaSndUnitClass {
 	GObjectClass parent_class;
@@ -70,8 +42,6 @@ struct _HinawaSndUnitClass {
 	 */
 	void (*disconnected)(HinawaSndUnit *self);
 };
-
-GType hinawa_snd_unit_get_type(void) G_GNUC_CONST;
 
 HinawaSndUnit *hinawa_snd_unit_new(void);
 


### PR DESCRIPTION
GObject v2.44 got new macro to declare GObject-derived objects. This
enables us to reduce boireplate for the declaration.

This patchset is to replace current boireplates with it.

```
Takashi Sakamoto (11):
  fw_node: use an utility macro to declare GObject-derived object
  fw_req: use an utility macro to declare GObject-derived object
  fw_resp: use an utility macro to declare GObject-derived object
  fw_fcp: use an utility macro to declare GObject-derived object
  snd_unit: use an utility macro to declare GObject-derived object
  snd_dg00x:: use an utility macro to declare GObject-derived object
  snd_dice: use an utility macro to declare GObject-derived object
  snd_efw: use an utility macro to declare GObject-derived object
  snd_motu: use an utility macro to declare GObject-derived object
  snd_tscm: use an utility macro to declare GObject-derived object
  update README to use working directory option of meson subcommands

 README.rst      | 22 +++++++++++-----------
 src/fw_fcp.c    |  4 ++--
 src/fw_fcp.h    | 32 +-------------------------------
 src/fw_node.c   | 15 +++++++--------
 src/fw_node.h   | 32 +-------------------------------
 src/fw_req.c    |  4 ++--
 src/fw_req.h    | 32 +-------------------------------
 src/fw_resp.c   |  4 ++--
 src/fw_resp.h   | 32 +-------------------------------
 src/meson.build |  2 +-
 src/snd_dg00x.h | 29 +----------------------------
 src/snd_dice.c  |  4 ++--
 src/snd_dice.h  | 32 +-------------------------------
 src/snd_efw.c   |  4 ++--
 src/snd_efw.h   | 32 +-------------------------------
 src/snd_motu.c  |  4 ++--
 src/snd_motu.h  | 32 +-------------------------------
 src/snd_tscm.c  |  4 ++--
 src/snd_tscm.h  | 32 +-------------------------------
 src/snd_unit.c  |  4 ++--
 src/snd_unit.h  | 32 +-------------------------------
 21 files changed, 45 insertions(+), 343 deletions(-)
```