### PR TITLE
[PATCH 0/6] tests: refine test implementation

### DIFF
--- a/tests/fw-fcp
+++ b/tests/fw-fcp
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.FwFcp()
+target_type = Hinawa.FwFcp
 props = (
     'timeout',
     'is-bound',
@@ -29,5 +29,5 @@ signals = (
     'responded',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-fcp
+++ b/tests/fw-fcp
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -29,5 +29,5 @@ signals = (
     'responded',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-node
+++ b/tests/fw-node
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.FwNode()
+target_type = Hinawa.FwNode
 props = (
     'node-id',
     'local-node-id',
@@ -33,5 +33,5 @@ signals = (
     'disconnected',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-node
+++ b/tests/fw-node
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -33,5 +33,5 @@ signals = (
     'disconnected',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-req
+++ b/tests/fw-req
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -26,5 +26,5 @@ signals = (
     'responded',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-req
+++ b/tests/fw-req
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.FwReq()
+target_type = Hinawa.FwReq
 props = (
     'timeout',
 )
@@ -26,5 +26,5 @@ signals = (
     'responded',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-resp
+++ b/tests/fw-resp
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.FwResp()
+target_type = Hinawa.FwResp
 props = (
     'is-reserved',
     'offset',
@@ -32,5 +32,5 @@ signals = (
     'requested2',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/fw-resp
+++ b/tests/fw-resp
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -32,5 +32,5 @@ signals = (
     'requested2',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -31,3 +31,11 @@ def test_enums(target_type: object, enumerations: tuple[str]) -> bool:
                 enumeration, target_type))
             return False
     return True
+
+
+def test_struct(target_type: object, methods: tuple[str]) -> bool:
+    for method in methods:
+        if not hasattr(target_type, method):
+            print('Method {0} is not produced.'.format(method))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,24 +1,37 @@
-import gi
-gi.require_version('GObject', '2.0')
-from gi.repository import GObject
-
-def test_object(target_type, props, methods, vmethods, signals) ->bool:
-    labels = [prop.name for prop in target_type.props]
-    for prop in props:
-        if prop not in labels:
-            print('Property {0} is not produced.'.format(prop))
-            return False
+def test_object(target_type: object, props: tuple[str], methods: tuple[str],
+                vmethods: tuple[str], signals: tuple[str]) -> bool:
+    # All of available methods are put into the list of attribute.
     for method in methods:
         if not hasattr(target_type, method):
             print('Method {0} is not produced.'.format(method))
             return False
+
+    # The properties, virtual methods, and signals in interface are not put
+    # into the list of attribute in object implementing the interface.
+    prop_labels = []
+    vmethod_labels = []
+    signal_labels = []
+
+    # The  gi.ObjectInfo and gi.InterfaceInfo keeps them. Let's traverse them.
+    for info in target_type.__mro__:
+        if hasattr(info, '__info__'):
+            for prop in info.__info__.get_properties():
+                prop_labels.append(prop.get_name())
+            for vfunc in info.__info__.get_vfuncs():
+                vmethod_labels.append('do_' + vfunc.get_name())
+            for signal in info.__info__.get_signals():
+                signal_labels.append(signal.get_name())
+
+    for prop in props:
+        if prop not in prop_labels:
+            print('Property {0} is not produced.'.format(prop))
+            return False
     for vmethod in vmethods:
-        if not hasattr(target_type, method):
+        if vmethod not in vmethod_labels:
             print('Vmethod {0} is not produced.'.format(vmethod))
             return False
-    labels = GObject.signal_list_names(target_type)
     for signal in signals:
-        if signal not in labels:
+        if signal not in signal_labels:
             print('Signal {0} is not produced.'.format(signal))
             return False
     return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -2,7 +2,7 @@ import gi
 gi.require_version('GObject', '2.0')
 from gi.repository import GObject
 
-def test(target, props, methods, vmethods, signals) ->bool:
+def test_object(target, props, methods, vmethods, signals) ->bool:
     labels = [prop.name for prop in target.props]
     for prop in props:
         if prop not in labels:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -22,3 +22,12 @@ def test_object(target, props, methods, vmethods, signals) ->bool:
             print('Signal {0} is not produced.'.format(signal))
             return False
     return True
+
+
+def test_enums(target_type: object, enumerations: tuple[str]) -> bool:
+    for enumeration in enumerations:
+        if not hasattr(target_type, enumeration):
+            print('Enumeration {0} is not produced for {1}.'.format(
+                enumeration, target_type))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -39,3 +39,11 @@ def test_struct(target_type: object, methods: tuple[str]) -> bool:
             print('Method {0} is not produced.'.format(method))
             return False
     return True
+
+
+def test_functions(target_type: object, functions: tuple[str]) -> bool:
+    for function in functions:
+        if not hasattr(target_type, function):
+            print('Function {0} is not produced.'.format(function))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -2,21 +2,21 @@ import gi
 gi.require_version('GObject', '2.0')
 from gi.repository import GObject
 
-def test_object(target, props, methods, vmethods, signals) ->bool:
-    labels = [prop.name for prop in target.props]
+def test_object(target_type, props, methods, vmethods, signals) ->bool:
+    labels = [prop.name for prop in target_type.props]
     for prop in props:
         if prop not in labels:
             print('Property {0} is not produced.'.format(prop))
             return False
     for method in methods:
-        if not hasattr(target, method):
+        if not hasattr(target_type, method):
             print('Method {0} is not produced.'.format(method))
             return False
     for vmethod in vmethods:
-        if not hasattr(target, method):
+        if not hasattr(target_type, method):
             print('Vmethod {0} is not produced.'.format(vmethod))
             return False
-    labels = GObject.signal_list_names(target)
+    labels = GObject.signal_list_names(target_type)
     for signal in signals:
         if signal not in labels:
             print('Signal {0} is not produced.'.format(signal))

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test_object
+from helper import test_enums
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -132,8 +132,6 @@ types = {
     Hinawa.SndEfwStatus: snd_efw_status_enumerators,
 }
 
-for obj, types in types.items():
-    for t in types:
-        if not hasattr(obj, t):
-            print('Enumerator {0} is not produced.'.format(t))
-            exit(ENXIO)
+for target_type, enumerations in types.items():
+    if not test_enums(target_type, enumerations):
+        exit(ENXIO)

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')

--- a/tests/hinawa-functions
+++ b/tests/hinawa-functions
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+import gi
+gi.require_version('Hinawa', '3.0')
+from gi.repository import Hinawa
+
+from helper import test_functions
+
+types = {
+    Hinawa.FwNodeError: (
+        'quark',
+    ),
+    Hinawa.FwReqError: (
+        'quark',
+    ),
+    Hinawa.FwRespError: (
+        'quark',
+    ),
+    Hinawa.FwFcpError: (
+        'quark',
+    ),
+    Hinawa.SndUnitError: (
+        'quark',
+    ),
+    Hinawa.SndDiceError: (
+        'quark',
+    ),
+}
+
+for target_type, functions in types.items():
+    if not test_functions(target_type, functions):
+        exit(ENXIO)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ tests = [
   'snd-tscm',
   'hinawa-enum',
   'snd-motu-register-dsp-parameter',
+  'hinawa-functions',
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,7 @@ tests = [
   'snd-motu',
   'snd-tscm',
   'hinawa-enum',
+  'snd-motu-register-dsp-parameter',
 ]
 
 envs = environment()

--- a/tests/snd-dg00x
+++ b/tests/snd-dg00x
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.SndDg00x()
+target_type = Hinawa.SndDg00x
 props = ()
 methods = (
     'open',
@@ -21,5 +21,5 @@ signals = (
     'message',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-dg00x
+++ b/tests/snd-dg00x
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -21,5 +21,5 @@ signals = (
     'message',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-dice
+++ b/tests/snd-dice
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.SndDice()
+target_type = Hinawa.SndDice
 props = ()
 methods = (
     'new',
@@ -23,5 +23,5 @@ signals = (
     'notified',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-dice
+++ b/tests/snd-dice
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -23,5 +23,5 @@ signals = (
     'notified',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-efw
+++ b/tests/snd-efw
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.SndEfw()
+target_type = Hinawa.SndEfw
 props = ()
 methods = (
     'new',
@@ -23,5 +23,5 @@ signals = (
     'responded',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-efw
+++ b/tests/snd-efw
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -23,5 +23,5 @@ signals = (
     'responded',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-motu
+++ b/tests/snd-motu
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -27,5 +27,5 @@ signals = (
     'register-dsp-changed',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-motu
+++ b/tests/snd-motu
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.SndMotu()
+target_type = Hinawa.SndMotu
 props = ()
 methods = (
     'new',
@@ -27,5 +27,5 @@ signals = (
     'register-dsp-changed',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-motu-register-dsp-parameter
+++ b/tests/snd-motu-register-dsp-parameter
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('Hinawa', '3.0')
+from gi.repository import Hinawa
+
+target_type = Hinawa.SndMotuRegisterDspParameter
+methods = (
+    'new',
+    'get_mixer_source_gain',
+    'get_mixer_source_pan',
+    'get_mixer_source_flag',
+    'get_mixer_source_paired_balance',
+    'get_mixer_source_paired_width',
+    'get_mixer_output_paired_volume',
+    'get_mixer_output_paired_flag',
+    'get_main_output_paired_volume',
+    'get_headphone_output_paired_volume',
+    'get_headphone_output_paired_assignment',
+    'get_line_input_boost_flag',
+    'get_line_input_nominal_level_flag',
+    'get_input_gain_and_invert',
+    'get_input_flag',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/snd-tscm
+++ b/tests/snd-tscm
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -23,5 +23,5 @@ signals = (
     'control',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-tscm
+++ b/tests/snd-tscm
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.SndTscm()
+target_type = Hinawa.SndTscm
 props = ()
 methods = (
     'new',
@@ -23,5 +23,5 @@ signals = (
     'control',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-unit
+++ b/tests/snd-unit
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hinawa', '3.0')
 from gi.repository import Hinawa
 
-target = Hinawa.SndUnit()
+target_type = Hinawa.SndUnit
 props = (
     'type',
     'card',
@@ -33,5 +33,5 @@ signals = (
     'disconnected',
 )
 
-if not test_object(target, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-unit
+++ b/tests/snd-unit
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hinawa', '3.0')
@@ -33,5 +33,5 @@ signals = (
     'disconnected',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test_object(target, props, methods, vmethods, signals):
     exit(ENXIO)


### PR DESCRIPTION
Current implementation of test just supports GObject-derived object,
enumerations, and flags. It's not possible to test the other types of
glib/gobject elements such as boxed structure.

This patchset refines test implementation. Some helper functions for
boxed structure and namespace/object functions are added. The existent
helper function is renamed as 'test_object' and rewritten to walk through
Python MRO hierarchy to check properties, virtual methods, and signals,
defined by both GObject-derived objects and interfaces.

I note that the tests are not done to execute actual symbols. They are just
to check they are available or not via interface described in metadata of
GObject Introspection.

```
Takashi Sakamoto (6):
  tests: rename helper function to test object interface
  tests: add helper function to test enumerations and flags
  tests: add test script for Hinawa.SndMotuRegisterDspParameter boxed
    structure
  tests: add test script for namespace and object functions
  tests: test object type instead of its instance
  tests: refine helper function to test object

 tests/fw-fcp                          |  6 +--
 tests/fw-node                         |  6 +--
 tests/fw-req                          |  6 +--
 tests/fw-resp                         |  6 +--
 tests/helper.py                       | 64 +++++++++++++++++++++------
 tests/hinawa-enum                     | 10 ++---
 tests/hinawa-functions                | 35 +++++++++++++++
 tests/meson.build                     |  2 +
 tests/snd-dg00x                       |  6 +--
 tests/snd-dice                        |  6 +--
 tests/snd-efw                         |  6 +--
 tests/snd-motu                        |  6 +--
 tests/snd-motu-register-dsp-parameter | 32 ++++++++++++++
 tests/snd-tscm                        |  6 +--
 tests/snd-unit                        |  6 +--
 15 files changed, 154 insertions(+), 49 deletions(-)
 create mode 100644 tests/hinawa-functions
 create mode 100644 tests/snd-motu-register-dsp-parameter
```