### PR TITLE
[PATCH 0/4] fw_resp: emit events under old ABI kernel

### DIFF
--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_FCP	(hinawa_fw_fcp_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaFwFcp, hinawa_fw_fcp, HINAWA, FW_FCP, HinawaFwResp);
+G_DECLARE_DERIVABLE_TYPE(HinawaFwFcp, hinawa_fw_fcp, HINAWA, FW_FCP, HinawaFwResp)
 
 #define HINAWA_FW_FCP_ERROR	hinawa_fw_fcp_error_quark()
 

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -477,9 +477,20 @@ static gboolean dispatch_src(GSource *gsrc, GSourceFunc cb, gpointer user_data)
 
 	if (HINAWA_IS_FW_NODE(instance) && event_type == FW_CDEV_EVENT_BUS_RESET) {
 		handle_update(src->self);
-	} else if (HINAWA_IS_FW_RESP(instance) && event_type == FW_CDEV_EVENT_REQUEST2) {
-		hinawa_fw_resp_handle_request(HINAWA_FW_RESP(instance), &event->request2);
-	} else if (HINAWA_IS_FW_REQ(instance) && event->common.type == FW_CDEV_EVENT_RESPONSE) {
+	} else if (HINAWA_IS_FW_RESP(instance)) {
+		HinawaFwResp *resp = HINAWA_FW_RESP(instance);
+
+		switch (event_type) {
+		case FW_CDEV_EVENT_REQUEST:
+			hinawa_fw_resp_handle_request(resp, &event->request);
+			break;
+		case FW_CDEV_EVENT_REQUEST2:
+			hinawa_fw_resp_handle_request2(resp, &event->request2);
+			break;
+		default:
+			break;
+		}
+	} else if (HINAWA_IS_FW_REQ(instance)) {
 		HinawaFwReq *req = HINAWA_FW_REQ(instance);
 		GList *entry;
 

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -447,7 +447,7 @@ static gboolean dispatch_src(GSource *gsrc, GSourceFunc cb, gpointer user_data)
 	FwNodeSource *src = (FwNodeSource *)gsrc;
 	HinawaFwNodePrivate *priv;
 	GIOCondition condition;
-	union fw_cdev_event *event;
+	const union fw_cdev_event *event;
 	gpointer instance;
 	__u32 event_type;
 	ssize_t len;
@@ -471,7 +471,7 @@ static gboolean dispatch_src(GSource *gsrc, GSourceFunc cb, gpointer user_data)
 		return G_SOURCE_REMOVE;
 	}
 
-	event = (union fw_cdev_event *)src->buf;
+	event = (const union fw_cdev_event *)src->buf;
 	instance = (gpointer)event->common.closure;
 	event_type = event->common.type;
 

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_NODE	(hinawa_fw_node_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaFwNode, hinawa_fw_node, HINAWA, FW_NODE, GObject);
+G_DECLARE_DERIVABLE_TYPE(HinawaFwNode, hinawa_fw_node, HINAWA, FW_NODE, GObject)
 
 #define HINAWA_FW_NODE_ERROR	hinawa_fw_node_error_quark()
 

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -418,8 +418,7 @@ void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 }
 
 // NOTE: For HinawaFwNode, internal.
-void hinawa_fw_req_handle_response(HinawaFwReq *self,
-				   struct fw_cdev_event_response *event)
+void hinawa_fw_req_handle_response(HinawaFwReq *self, const struct fw_cdev_event_response *event)
 {
 	g_return_if_fail(HINAWA_IS_FW_REQ(self));
 

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_REQ	(hinawa_fw_req_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaFwReq, hinawa_fw_req, HINAWA, FW_REQ, GObject);
+G_DECLARE_DERIVABLE_TYPE(HinawaFwReq, hinawa_fw_req, HINAWA, FW_REQ, GObject)
 
 #define HINAWA_FW_REQ_ERROR	hinawa_fw_req_error_quark()
 

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -413,8 +413,7 @@ void hinawa_fw_resp_set_resp_frame(HinawaFwResp *self, guint8 *frame,
 }
 
 // NOTE: For HinawaFwNodee, internal.
-void hinawa_fw_resp_handle_request(HinawaFwResp *self,
-				   struct fw_cdev_event_request2 *event)
+void hinawa_fw_resp_handle_request(HinawaFwResp *self, const struct fw_cdev_event_request2 *event)
 {
 	HinawaFwRespPrivate *priv;
 	HinawaFwRespClass *klass;

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_FW_RESP	(hinawa_fw_resp_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaFwResp, hinawa_fw_resp, HINAWA, FW_RESP, GObject);
+G_DECLARE_DERIVABLE_TYPE(HinawaFwResp, hinawa_fw_resp, HINAWA, FW_RESP, GObject)
 
 #define HINAWA_FW_RESP_ERROR	hinawa_fw_resp_error_quark()
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -7,10 +7,8 @@
 int hinawa_fw_node_ioctl(HinawaFwNode *self, unsigned long req, void *args, GError **exception);
 void hinawa_fw_node_invalidate_transaction(HinawaFwNode *self, HinawaFwReq *req);
 
-void hinawa_fw_resp_handle_request(HinawaFwResp *self,
-				   struct fw_cdev_event_request2 *event);
-void hinawa_fw_req_handle_response(HinawaFwReq *self,
-				   struct fw_cdev_event_response *event);
+void hinawa_fw_resp_handle_request(HinawaFwResp *self, const struct fw_cdev_event_request2 *event);
+void hinawa_fw_req_handle_response(HinawaFwReq *self, const struct fw_cdev_event_response *event);
 
 void hinawa_snd_unit_write(HinawaSndUnit *self, const void *buf, size_t length,
 			   GError **exception);

--- a/src/internal.h
+++ b/src/internal.h
@@ -7,7 +7,8 @@
 int hinawa_fw_node_ioctl(HinawaFwNode *self, unsigned long req, void *args, GError **exception);
 void hinawa_fw_node_invalidate_transaction(HinawaFwNode *self, HinawaFwReq *req);
 
-void hinawa_fw_resp_handle_request(HinawaFwResp *self, const struct fw_cdev_event_request2 *event);
+void hinawa_fw_resp_handle_request(HinawaFwResp *self, const struct fw_cdev_event_request *event);
+void hinawa_fw_resp_handle_request2(HinawaFwResp *self, const struct fw_cdev_event_request2 *event);
 void hinawa_fw_req_handle_response(HinawaFwReq *self, const struct fw_cdev_event_response *event);
 
 void hinawa_snd_unit_write(HinawaSndUnit *self, const void *buf, size_t length,

--- a/src/snd_dg00x.h
+++ b/src/snd_dg00x.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_DG00X	(hinawa_snd_dg00x_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaSndDg00x, hinawa_snd_dg00x, HINAWA, SND_DG00X, HinawaSndUnit);
+G_DECLARE_DERIVABLE_TYPE(HinawaSndDg00x, hinawa_snd_dg00x, HINAWA, SND_DG00X, HinawaSndUnit)
 
 struct _HinawaSndDg00xClass {
 	HinawaSndUnitClass parent_class;

--- a/src/snd_dice.h
+++ b/src/snd_dice.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_DICE	(hinawa_snd_dice_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaSndDice, hinawa_snd_dice, HINAWA, SND_DICE, HinawaSndUnit);
+G_DECLARE_DERIVABLE_TYPE(HinawaSndDice, hinawa_snd_dice, HINAWA, SND_DICE, HinawaSndUnit)
 
 #define HINAWA_SND_DICE_ERROR	hinawa_snd_dice_error_quark()
 

--- a/src/snd_efw.h
+++ b/src/snd_efw.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_EFW	(hinawa_snd_efw_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaSndEfw, hinawa_snd_efw, HINAWA, SND_EFW, HinawaSndUnit);
+G_DECLARE_DERIVABLE_TYPE(HinawaSndEfw, hinawa_snd_efw, HINAWA, SND_EFW, HinawaSndUnit)
 
 #define HINAWA_SND_EFW_ERROR	hinawa_snd_efw_error_quark()
 

--- a/src/snd_motu.h
+++ b/src/snd_motu.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_MOTU	(hinawa_snd_motu_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaSndMotu, hinawa_snd_motu, HINAWA, SND_MOTU, HinawaSndUnit);
+G_DECLARE_DERIVABLE_TYPE(HinawaSndMotu, hinawa_snd_motu, HINAWA, SND_MOTU, HinawaSndUnit)
 
 struct _HinawaSndMotuClass {
 	HinawaSndUnitClass parent_class;

--- a/src/snd_tscm.h
+++ b/src/snd_tscm.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_TSCM	(hinawa_snd_tscm_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaSndTscm, hinawa_snd_tscm, HINAWA, SND_TSCM, HinawaSndUnit);
+G_DECLARE_DERIVABLE_TYPE(HinawaSndTscm, hinawa_snd_tscm, HINAWA, SND_TSCM, HinawaSndUnit)
 
 struct _HinawaSndTscmClass {
 	HinawaSndUnitClass parent_class;

--- a/src/snd_unit.h
+++ b/src/snd_unit.h
@@ -8,7 +8,7 @@ G_BEGIN_DECLS
 
 #define HINAWA_TYPE_SND_UNIT	(hinawa_snd_unit_get_type())
 
-G_DECLARE_DERIVABLE_TYPE(HinawaSndUnit, hinawa_snd_unit, HINAWA, SND_UNIT, GObject);
+G_DECLARE_DERIVABLE_TYPE(HinawaSndUnit, hinawa_snd_unit, HINAWA, SND_UNIT, GObject)
 
 #define HINAWA_SND_UNIT_ERROR	hinawa_snd_unit_error_quark()
 


### PR DESCRIPTION
When application runs in Linux kernel with old ABI of FireWire subsystem,
some event is not available. For the case, current implementation does
not emit GObject signal corresponding to it. It's inconvenient.

This commit emits the GObject signal in the case as well as refactors code.

```
Takashi Sakamoto (4):
  fw_node: code refactoring to use union type to distinguish events
  fw_node: code refactoring to use const qualifier to buffer of event
  fw_resp: get previous version of event back for request event
  all: remove trailing semicolon when using G_DECLARE_DERIVABLE_TYPE

 src/fw_fcp.h    |  2 +-
 src/fw_node.c   | 33 +++++++++++++++++++++---------
 src/fw_node.h   |  2 +-
 src/fw_req.c    |  3 +--
 src/fw_req.h    |  2 +-
 src/fw_resp.c   | 54 ++++++++++++++++++++++++++++++++++++++++++++-----
 src/fw_resp.h   |  2 +-
 src/internal.h  |  7 +++----
 src/snd_dg00x.h |  2 +-
 src/snd_dice.h  |  2 +-
 src/snd_efw.h   |  2 +-
 src/snd_motu.h  |  2 +-
 src/snd_tscm.h  |  2 +-
 src/snd_unit.h  |  2 +-
 14 files changed, 86 insertions(+), 31 deletions(-)
```