### PR TITLE
[PATCH 0/5] use caller-allocate strategy for fixed-size of array

### DIFF
--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -88,8 +88,8 @@ def read_quadlet(node: Hinawa.FwNode, req: Hinawa.FwReq, addr: int) -> int:
     except Exception as e:
         print(e)
 
-    sent_cycle = cycle_time.compute_tstamp(tstamp[0], [0] * 2)
-    recv_cycle = cycle_time.compute_tstamp(tstamp[1], [0] * 2)
+    sent_cycle = cycle_time.compute_tstamp(tstamp[0])
+    recv_cycle = cycle_time.compute_tstamp(tstamp[1])
 
     try:
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
@@ -150,7 +150,7 @@ def handle_requested3(resp: Hinawa.FwResp, tcode: Hinawa.FwRcode, offset: int,
     print('Event requested3: {0}'.format(tcode.value_nick))
     try:
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
-        isoc_cycle = cycle_time.compute_tstamp(tstamp, [0] * 2)
+        isoc_cycle = cycle_time.compute_tstamp(tstamp)
     except Exception as e:
         print(e)
         isoc_cycle = [0] * 2
@@ -181,7 +181,7 @@ def handle_responded2(fcp: Hinawa.FwFcp, frame: list, length: int, tstamp: int,
     print('Event responded2: length {}'.format(length))
     try:
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
-        isoc_cycle = cycle_time.compute_tstamp(tstamp, [0] * 2)
+        isoc_cycle = cycle_time.compute_tstamp(tstamp)
     except Exception as e:
         print(e)
         isoc_cycle = [0] * 2
@@ -207,9 +207,9 @@ def listen_fcp(node: Hinawa.FwNode):
         _, response, tstamp = fcp.avc_transaction_with_tstamp(request, [0] * len(request), tstamp,
                                                               100)
 
-        req_sent_cycle = cycle_time.compute_tstamp(tstamp[0], [0] * 2)
-        req_responded_cycle = cycle_time.compute_tstamp(tstamp[1], [0] * 2)
-        resp_sent_cycle = cycle_time.compute_tstamp(tstamp[2], [0] * 2)
+        req_sent_cycle = cycle_time.compute_tstamp(tstamp[0])
+        req_responded_cycle = cycle_time.compute_tstamp(tstamp[1])
+        resp_sent_cycle = cycle_time.compute_tstamp(tstamp[2])
 
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
         finish_cycle = cycle_time.get_fields()[:2]

--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -200,10 +200,8 @@ def listen_fcp(node: Hinawa.FwNode):
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
         initiate_cycle = cycle_time.get_fields()[:2]
 
-        tstamp = [0] * 3
         request = bytes([0x01, 0xff, 0x19, 0x00, 0xff, 0xff, 0xff, 0xff])
-        _, response, tstamp = fcp.avc_transaction_with_tstamp(request, [0] * len(request), tstamp,
-                                                              100)
+        _, response, tstamp = fcp.avc_transaction_with_tstamp(request, [0] * len(request), 100)
 
         req_sent_cycle = cycle_time.compute_tstamp(tstamp[0])
         req_responded_cycle = cycle_time.compute_tstamp(tstamp[1])

--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -74,7 +74,6 @@ def read_quadlet(node: Hinawa.FwNode, req: Hinawa.FwReq, addr: int) -> int:
     initiate_cycle = cycle_time.get_fields()[:2]
 
     frame = [0] * 4
-    tstamp = [0] * 2
     try:
         _, frame, tstamp = req.transaction_with_tstamp_sync(
             node,
@@ -82,7 +81,6 @@ def read_quadlet(node: Hinawa.FwNode, req: Hinawa.FwReq, addr: int) -> int:
             addr,
             len(frame),
             frame,
-            tstamp,
             100
         )
     except Exception as e:

--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -71,7 +71,7 @@ def read_quadlet(node: Hinawa.FwNode, req: Hinawa.FwReq, addr: int) -> int:
     except Exception as e:
         print(e)
         return 0
-    initiate_cycle = cycle_time.get_fields()
+    initiate_cycle = cycle_time.get_fields()[:2]
 
     frame = [0] * 4
     tstamp = [0] * 2
@@ -96,7 +96,7 @@ def read_quadlet(node: Hinawa.FwNode, req: Hinawa.FwReq, addr: int) -> int:
     except Exception as e:
         print(e)
         return 0
-    finish_cycle = cycle_time.get_fields()
+    finish_cycle = cycle_time.get_fields()[:2]
 
     quadlet = unpack('>I', frame)[0]
 
@@ -200,7 +200,7 @@ def listen_fcp(node: Hinawa.FwNode):
         fcp.bind(node)
 
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
-        initiate_cycle = cycle_time.get_fields()
+        initiate_cycle = cycle_time.get_fields()[:2]
 
         tstamp = [0] * 3
         request = bytes([0x01, 0xff, 0x19, 0x00, 0xff, 0xff, 0xff, 0xff])
@@ -212,7 +212,7 @@ def listen_fcp(node: Hinawa.FwNode):
         resp_sent_cycle = cycle_time.compute_tstamp(tstamp[2], [0] * 2)
 
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
-        finish_cycle = cycle_time.get_fields()
+        finish_cycle = cycle_time.get_fields()[:2]
 
         print('FCP request:')
         print_frame(request)

--- a/src/cycle_time.c
+++ b/src/cycle_time.c
@@ -136,9 +136,10 @@ void hinawa_cycle_time_get_raw(const HinawaCycleTime *self, guint32 *raw)
  * hinawa_cycle_time_compute_tstamp:
  * @self: A [struct@CycleTime].
  * @tstamp: The value of time stamp retrieved from each context of 1394 OHCI.
- * @isoc_cycle: (array fixed-size=2) (inout): The result to parse the time stamp. The first element
- *	    is for 7 bits of second field in the format of IEEE 1394 CYCLE_TIME register, up to
- *	    127. The second element is for 13 bits of cycle field in the format, up to 7,999.
+ * @isoc_cycle: (array fixed-size=2)(out caller-allocates): The result to parse the time stamp. The
+ *		first element is for 7 bits of second field in the format of IEEE 1394 CYCLE_TIME
+ *		register, up to 127. The second element is for 13 bits of cycle field in the format,
+ *		up to 7,999.
  *
  * Compute second count and cycle count from unsigned 16 bit integer value retrieved by Asynchronous
  * Transmit (AT), Asynchronous Receive(AR), Isochronous Transmit (IT), and Isochronous Receive (IR)
@@ -149,7 +150,7 @@ void hinawa_cycle_time_get_raw(const HinawaCycleTime *self, guint32 *raw)
  *
  * Since: 2.6
  */
-void hinawa_cycle_time_compute_tstamp(const HinawaCycleTime *self, guint tstamp, guint **isoc_cycle)
+void hinawa_cycle_time_compute_tstamp(const HinawaCycleTime *self, guint tstamp, guint isoc_cycle[2])
 {
 	guint tstamp_sec_low = (tstamp & OHCI1394_TSTAMP_SEC_MASK) >> OHCI1394_TSTAMP_SEC_SHIFT;
 	guint curr_sec_low = ieee1394_cycle_time_to_sec(self->cycle_timer) & 0x7;
@@ -161,16 +162,17 @@ void hinawa_cycle_time_compute_tstamp(const HinawaCycleTime *self, guint tstamp,
 	sec |= tstamp_sec_low;
 	sec %= IEEE1394_SEC_MAX;
 
-	(*isoc_cycle)[0] = sec;
-	(*isoc_cycle)[1] = (tstamp & OHCI1394_TSTAMP_CYCLE_MASK) >> OHCI1394_TSTAMP_CYCLE_SHIFT;
+	isoc_cycle[0] = sec;
+	isoc_cycle[1] = (tstamp & OHCI1394_TSTAMP_CYCLE_MASK) >> OHCI1394_TSTAMP_CYCLE_SHIFT;
 }
 
 /**
  * hinawa_cycle_time_parse_tstamp:
  * @tstamp: The value of time stamp retrieved from each context of 1394 OHCI.
- * @isoc_cycle: (array fixed-size=2) (inout): The result to parse the time stamp. The first element
- *	    is for three order bits of second field in the format of IEEE 1394 CYCLE_TIME register,
- *	    up to 7. The second element is for 13 bits of cycle field in the format, up to 7,999.
+ * @isoc_cycle: (array fixed-size=2)(out caller-allocates): The result to parse the time stamp. The
+ *		first element is for three order bits of second field in the format of IEEE 1394
+ *		CYCLE_TIME register, up to 7. The second element is for 13 bits of cycle field in
+ *		the format, up to 7,999.
  *
  * Parse second count and cycle count from unsigned 16 bit integer value retrieved by Asynchronous
  * Transmit (AT), Asynchronous Receive(AR), Isochronous Transmit (IT), and Isochronous Receive (IR)
@@ -178,8 +180,8 @@ void hinawa_cycle_time_compute_tstamp(const HinawaCycleTime *self, guint tstamp,
  *
  * Since: 2.6
  */
-void hinawa_cycle_time_parse_tstamp(guint tstamp, guint **isoc_cycle)
+void hinawa_cycle_time_parse_tstamp(guint tstamp, guint isoc_cycle[2])
 {
-	(*isoc_cycle)[0] = (tstamp & OHCI1394_TSTAMP_SEC_MASK) >> OHCI1394_TSTAMP_SEC_SHIFT;
-	(*isoc_cycle)[1] = (tstamp & OHCI1394_TSTAMP_CYCLE_MASK) >> OHCI1394_TSTAMP_CYCLE_SHIFT;
+	isoc_cycle[0] = (tstamp & OHCI1394_TSTAMP_SEC_MASK) >> OHCI1394_TSTAMP_SEC_SHIFT;
+	isoc_cycle[1] = (tstamp & OHCI1394_TSTAMP_CYCLE_MASK) >> OHCI1394_TSTAMP_CYCLE_SHIFT;
 }

--- a/src/cycle_time.c
+++ b/src/cycle_time.c
@@ -94,8 +94,8 @@ static guint ieee1394_cycle_time_to_offset(guint32 cycle_time)
 /**
  * hinawa_cycle_time_get_fields:
  * @self: A [struct@CycleTime].
- * @cycle_time: (array fixed-size=3) (out caller-allocates): The value of cycle time register of
- *		 1394 OHCI, including three elements; second, cycle, and offset.
+ * @fields: (array fixed-size=3) (out caller-allocates): The value of cycle time register of 1394
+ *	    OHCI, including three elements; second, cycle, and offset in its order.
  *
  * Get the value of cycle time in 1394 OHCI controller. The first element of array expresses the
  * value of sec field, up to 127. The second element of array expresses the value of cycle field,
@@ -103,11 +103,11 @@ static guint ieee1394_cycle_time_to_offset(guint32 cycle_time)
  *
  * Since: 2.6.
  */
-void hinawa_cycle_time_get_fields(const HinawaCycleTime *self, guint16 cycle_time[3])
+void hinawa_cycle_time_get_fields(const HinawaCycleTime *self, guint16 fields[3])
 {
-	cycle_time[0] = ieee1394_cycle_time_to_sec(self->cycle_timer);
-	cycle_time[1] = ieee1394_cycle_time_to_cycle(self->cycle_timer);
-	cycle_time[2] = ieee1394_cycle_time_to_offset(self->cycle_timer);
+	fields[0] = ieee1394_cycle_time_to_sec(self->cycle_timer);
+	fields[1] = ieee1394_cycle_time_to_cycle(self->cycle_timer);
+	fields[2] = ieee1394_cycle_time_to_offset(self->cycle_timer);
 }
 
 /**

--- a/src/cycle_time.c
+++ b/src/cycle_time.c
@@ -48,7 +48,7 @@ HinawaCycleTime *hinawa_cycle_time_new()
  *
  * Since: 2.6.
  */
-void hinawa_cycle_time_get_system_time(HinawaCycleTime *self, gint64 *tv_sec, gint32 *tv_nsec)
+void hinawa_cycle_time_get_system_time(const HinawaCycleTime *self, gint64 *tv_sec, gint32 *tv_nsec)
 {
 	*tv_sec = self->tv_sec;
 	*tv_nsec = self->tv_nsec;
@@ -65,7 +65,7 @@ void hinawa_cycle_time_get_system_time(HinawaCycleTime *self, gint64 *tv_sec, gi
  *
  * Since: 2.6.
  */
-void hinawa_cycle_time_get_clock_id(HinawaCycleTime *self, gint *clock_id)
+void hinawa_cycle_time_get_clock_id(const HinawaCycleTime *self, gint *clock_id)
 {
 	*clock_id = self->clk_id;
 }
@@ -103,7 +103,7 @@ static guint ieee1394_cycle_time_to_offset(guint32 cycle_time)
  *
  * Since: 2.6.
  */
-void hinawa_cycle_time_get_fields(HinawaCycleTime *self, guint16 cycle_time[3])
+void hinawa_cycle_time_get_fields(const HinawaCycleTime *self, guint16 cycle_time[3])
 {
 	cycle_time[0] = ieee1394_cycle_time_to_sec(self->cycle_timer);
 	cycle_time[1] = ieee1394_cycle_time_to_cycle(self->cycle_timer);
@@ -119,7 +119,7 @@ void hinawa_cycle_time_get_fields(HinawaCycleTime *self, guint16 cycle_time[3])
  *
  * Since: 2.6.
  */
-void hinawa_cycle_time_get_raw(HinawaCycleTime *self, guint32 *raw)
+void hinawa_cycle_time_get_raw(const HinawaCycleTime *self, guint32 *raw)
 {
 	*raw = self->cycle_timer;
 }
@@ -149,7 +149,7 @@ void hinawa_cycle_time_get_raw(HinawaCycleTime *self, guint32 *raw)
  *
  * Since: 2.6
  */
-void hinawa_cycle_time_compute_tstamp(HinawaCycleTime *self, guint tstamp, guint **isoc_cycle)
+void hinawa_cycle_time_compute_tstamp(const HinawaCycleTime *self, guint tstamp, guint **isoc_cycle)
 {
 	guint tstamp_sec_low = (tstamp & OHCI1394_TSTAMP_SEC_MASK) >> OHCI1394_TSTAMP_SEC_SHIFT;
 	guint curr_sec_low = ieee1394_cycle_time_to_sec(self->cycle_timer) & 0x7;

--- a/src/cycle_time.h
+++ b/src/cycle_time.h
@@ -23,9 +23,9 @@ void hinawa_cycle_time_get_fields(const HinawaCycleTime *self, guint16 fields[3]
 
 void hinawa_cycle_time_get_raw(const HinawaCycleTime *self, guint32 *raw);
 
-void hinawa_cycle_time_compute_tstamp(const HinawaCycleTime *self, guint tstamp, guint **isoc_cycle);
+void hinawa_cycle_time_compute_tstamp(const HinawaCycleTime *self, guint tstamp, guint isoc_cycle[2]);
 
-void hinawa_cycle_time_parse_tstamp(guint tstamp, guint **isoc_cycle);
+void hinawa_cycle_time_parse_tstamp(guint tstamp, guint isoc_cycle[2]);
 
 G_END_DECLS
 

--- a/src/cycle_time.h
+++ b/src/cycle_time.h
@@ -14,15 +14,16 @@ GType hinawa_cycle_time_get_type() G_GNUC_CONST;
 
 HinawaCycleTime *hinawa_cycle_time_new();
 
-void hinawa_cycle_time_get_system_time(HinawaCycleTime *self, gint64 *tv_sec, gint32 *tv_nsec);
+void hinawa_cycle_time_get_system_time(const HinawaCycleTime *self, gint64 *tv_sec,
+				       gint32 *tv_nsec);
 
-void hinawa_cycle_time_get_clock_id(HinawaCycleTime *self, gint *clock_id);
+void hinawa_cycle_time_get_clock_id(const HinawaCycleTime *self, gint *clock_id);
 
-void hinawa_cycle_time_get_fields(HinawaCycleTime *self, guint16 cycle_time[3]);
+void hinawa_cycle_time_get_fields(const HinawaCycleTime *self, guint16 cycle_time[3]);
 
-void hinawa_cycle_time_get_raw(HinawaCycleTime *self, guint32 *raw);
+void hinawa_cycle_time_get_raw(const HinawaCycleTime *self, guint32 *raw);
 
-void hinawa_cycle_time_compute_tstamp(HinawaCycleTime *self, guint tstamp, guint **isoc_cycle);
+void hinawa_cycle_time_compute_tstamp(const HinawaCycleTime *self, guint tstamp, guint **isoc_cycle);
 
 void hinawa_cycle_time_parse_tstamp(guint tstamp, guint **isoc_cycle);
 

--- a/src/cycle_time.h
+++ b/src/cycle_time.h
@@ -19,7 +19,7 @@ void hinawa_cycle_time_get_system_time(const HinawaCycleTime *self, gint64 *tv_s
 
 void hinawa_cycle_time_get_clock_id(const HinawaCycleTime *self, gint *clock_id);
 
-void hinawa_cycle_time_get_fields(const HinawaCycleTime *self, guint16 cycle_time[3]);
+void hinawa_cycle_time_get_fields(const HinawaCycleTime *self, guint16 fields[3]);
 
 void hinawa_cycle_time_get_raw(const HinawaCycleTime *self, guint32 *raw);
 

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -59,14 +59,14 @@ void hinawa_fw_fcp_unbind(HinawaFwFcp *self);
 void hinawa_fw_fcp_command(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
 			   guint timeout_ms, GError **error);
 gboolean hinawa_fw_fcp_command_with_tstamp(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
-					   guint **tstamp, guint timeout_ms, GError **error);
+					   guint tstamp[2], guint timeout_ms, GError **error);
 
 void hinawa_fw_fcp_avc_transaction(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
 				   guint8 *const *resp, gsize *resp_size, guint timeout_ms,
 				   GError **error);
 gboolean hinawa_fw_fcp_avc_transaction_with_tstamp(HinawaFwFcp *self, const guint8 *cmd,
 					gsize cmd_size, guint8 **resp, gsize *resp_size,
-					guint **tstamp, guint timeout_ms, GError **error);
+					guint tstamp[3], guint timeout_ms, GError **error);
 
 G_END_DECLS
 

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -460,9 +460,9 @@ void hinawa_fw_req_transaction_sync(HinawaFwReq *self, HinawaFwNode *node,
  *	   transaction.
  * @frame_size: The size of array in byte unit. The value of this argument should point to the
  *		numeric number and mutable for read and lock transaction.
- * @tstamp: (array fixed-size=2)(inout): The array with two elements for time stamps. The first
- *	    element is for the isochronous cycle at which the request was sent. The second element
- *	    is for the isochronous cycle at which the response arrived.
+ * @tstamp: (array fixed-size=2)(out caller-allocates): The array with two elements for time stamps.
+ *	    The first element is for the isochronous cycle at which the request was sent. The second
+ *	    element is for the isochronous cycle at which the response arrived.
  * @timeout_ms: The timeout to wait for response subaction of the transaction since request
  *		subaction is initiated, in milliseconds.
  * @error: A [struct@GLib.Error]. Error can be generated with two domains; Hinawa.FwNodeError and
@@ -483,17 +483,19 @@ void hinawa_fw_req_transaction_sync(HinawaFwReq *self, HinawaFwNode *node,
  */
 gboolean hinawa_fw_req_transaction_with_tstamp_sync(HinawaFwReq *self, HinawaFwNode *node,
 				HinawaFwTcode tcode, guint64 addr, gsize length,
-				guint8 **frame, gsize *frame_size, guint **tstamp,
+				guint8 **frame, gsize *frame_size, guint tstamp[2],
 				guint timeout_ms, GError **error)
 {
 	struct waiter w;
 	gboolean result;
 
+	g_return_val_if_fail(tstamp != NULL, FALSE);
+
 	result = complete_transaction(self, node, tcode, addr, length, frame, frame_size,
 				      timeout_ms, &w, error);
 	if (*error == NULL) {
-		(*tstamp)[0] = w.request_tstamp;
-		(*tstamp)[1] = w.response_tstamp;
+		tstamp[0] = w.request_tstamp;
+		tstamp[1] = w.response_tstamp;
 	}
 
 	return result;

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -65,7 +65,7 @@ void hinawa_fw_req_transaction_sync(HinawaFwReq *self, HinawaFwNode *node,
 
 gboolean hinawa_fw_req_transaction_with_tstamp_sync(HinawaFwReq *self, HinawaFwNode *node,
 				HinawaFwTcode tcode, guint64 addr, gsize length,
-				guint8 **frame, gsize *frame_size, guint **tstamp,
+				guint8 **frame, gsize *frame_size, guint tstamp[2],
 				guint timeout_ms, GError **error);
 
 void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,


### PR DESCRIPTION
PyGObject nowadays can handle argument with 'out caller-allocate' annotation expectedly for fixed-size of array, thus no need to use double pointer for out parameter.

This series is to simplify fixed-size of array processing.

```
Takashi Sakamoto (5):
  cycle_time: constify self parameter when retrieving parameter
  cycle_time: use suitable name for argument of fields
  cycle_time: use caller-allocate strategy for fixed-size of array
  fw_req: use caller-allocate strategy for fixed-size of array
  fw_fcp: use caller-allocate strategy for fixed-size of array

 samples/common/__init__.py | 28 +++++++---------
 src/cycle_time.c           | 44 +++++++++++++------------
 src/cycle_time.h           | 13 ++++----
 src/fw_fcp.c               | 67 +++++++++++++++-----------------------
 src/fw_fcp.h               |  4 +--
 src/fw_req.c               | 14 ++++----
 src/fw_req.h               |  2 +-
 7 files changed, 79 insertions(+), 93 deletions(-)
```