### PR TITLE
fw_req: obsolete usage of `sync` and `async` suffixes for method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,14 @@ Example of Python3 with PyGobject
     addr = 0xfffff0000404
     req = Hinawa.FwReq.new()
     frame = [0] * 4
-    frame = req.transaction_sync(node, Hinawa.FwTcode.READ_QUADLET_REQUEST, addr,
-                                 len(frame), frame, 50)
+    _, frame, tstamp = req.transaction_with_tstamp(
+        node,
+        Hinawa.FwTcode.READ_QUADLET_REQUEST,
+        addr,
+        len(frame),
+        frame,
+        50
+    )
     quad = unpack('>I', frame)[0]
     print('0x{:012x}: 0x{:02x}'.format(addr, quad))
 

--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -75,7 +75,7 @@ def read_quadlet(node: Hinawa.FwNode, req: Hinawa.FwReq, addr: int) -> int:
 
     frame = [0] * 4
     try:
-        _, frame, tstamp = req.transaction_with_tstamp_sync(
+        _, frame, tstamp = req.transaction_with_tstamp(
             node,
             Hinawa.FwTcode.READ_QUADLET_REQUEST,
             addr,

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -266,11 +266,11 @@ static gboolean complete_command_transaction(HinawaFwFcp *self, const guint8 *cm
 	req = g_object_new(HINAWA_TYPE_FW_REQ, NULL);
 
 	// Finish transaction for command frame.
-	result = hinawa_fw_req_transaction_with_tstamp_sync(req, priv->node,
-							    HINAWA_FW_TCODE_WRITE_BLOCK_REQUEST,
-							    FCP_REQUEST_ADDR, cmd_size,
-							    (guint8 **)&cmd, &cmd_size,
-							    tstamp, timeout_ms, error);
+	result = hinawa_fw_req_transaction_with_tstamp(req, priv->node,
+						       HINAWA_FW_TCODE_WRITE_BLOCK_REQUEST,
+						       FCP_REQUEST_ADDR, cmd_size,
+						       (guint8 **)&cmd, &cmd_size,
+						       tstamp, timeout_ms, error);
 	g_object_unref(req);
 
 	return result;

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -113,7 +113,7 @@ static void hinawa_fw_req_class_init(HinawaFwReqClass *klass)
 	 * HinawaFwReq:timeout:
 	 *
 	 * Since: 1.4
-	 * Deprecated: 2.1: Use timeout_ms parameter of [method@FwReq.transaction_sync].
+	 * Deprecated: 2.1: Use timeout_ms parameter of [method@FwReq.transaction_with_tstamp].
 	 */
 	fw_req_props[FW_REQ_PROP_TYPE_TIMEOUT] =
 		g_param_spec_uint("timeout", "timeout",
@@ -434,6 +434,7 @@ static gboolean complete_transaction(HinawaFwReq *self, HinawaFwNode *node, Hina
  * instance is ignored.
  *
  * Since: 2.1.
+ * Deprecated: 2.6. Use [method@FwReq.transaction_with_tstamp] instead.
  */
 void hinawa_fw_req_transaction_sync(HinawaFwReq *self, HinawaFwNode *node,
 			       HinawaFwTcode tcode, guint64 addr, gsize length,
@@ -447,7 +448,7 @@ void hinawa_fw_req_transaction_sync(HinawaFwReq *self, HinawaFwNode *node,
 }
 
 /**
- * hinawa_fw_req_transaction_with_tstamp_sync:
+ * hinawa_fw_req_transaction_with_tstamp:
  * @self: A [class@FwReq].
  * @node: A [class@FwNode].
  * @tcode: A transaction code of [enum@FwTcode].
@@ -481,10 +482,10 @@ void hinawa_fw_req_transaction_sync(HinawaFwReq *self, HinawaFwNode *node,
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  * Since: 2.6
  */
-gboolean hinawa_fw_req_transaction_with_tstamp_sync(HinawaFwReq *self, HinawaFwNode *node,
-				HinawaFwTcode tcode, guint64 addr, gsize length,
-				guint8 **frame, gsize *frame_size, guint tstamp[2],
-				guint timeout_ms, GError **error)
+gboolean hinawa_fw_req_transaction_with_tstamp(HinawaFwReq *self, HinawaFwNode *node,
+					       HinawaFwTcode tcode, guint64 addr, gsize length,
+					       guint8 **frame, gsize *frame_size, guint tstamp[2],
+					       guint timeout_ms, GError **error)
 {
 	struct waiter w;
 	gboolean result;
@@ -522,7 +523,7 @@ gboolean hinawa_fw_req_transaction_with_tstamp_sync(HinawaFwReq *self, HinawaFwN
  * for response subaction within the value of timeout argument.
  *
  * Since: 1.4
- * Deprecated: 2.1: Use [method@FwReq.transaction_sync] instead.
+ * Deprecated: 2.1: Use [method@FwReq.transaction_with_tstamp()] instead.
  */
 void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 			       HinawaFwTcode tcode, guint64 addr, gsize length,

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -273,6 +273,35 @@ static gboolean initiate_transaction(HinawaFwReq *self, HinawaFwNode *node, Hina
 	return err >= 0;
 }
 
+/**
+ * hinawa_fw_req_request:
+ * @self: A [class@FwReq].
+ * @node: A [class@FwNode].
+ * @tcode: A transaction code of [enum@FwTcode].
+ * @addr: A destination address of target device
+ * @length: The range of address in byte unit.
+ * @frame: (array length=frame_size)(inout): An array with elements for byte data. Callers should
+ *	   give it for buffer with enough space against the request since this library performs no
+ *	   reallocation. Due to the reason, the value of this argument should point to the pointer
+ *	   to the array and immutable. The content of array is mutable for read and lock
+ *	   transaction.
+ * @frame_size: The size of array in byte unit. The value of this argument should point to the
+ *		numerical number and mutable for read and lock transaction.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domains; Hinawa.FwNodeError and
+ *	   Hinawa.FwReqError.
+ *
+ * Execute request subaction of transactions to the given node according to given code. When the
+ * response subaction arrives and running event dispatcher reads the contents,
+ * [signal@FwReq::responded2] signal handler is called.
+ *
+ * Since: 2.6.
+ */
+gboolean hinawa_fw_req_request(HinawaFwReq *self, HinawaFwNode *node, HinawaFwTcode tcode,
+			       guint64 addr, gsize length, guint8 *const *frame, gsize *frame_size,
+			       GError **error)
+{
+	return initiate_transaction(self, node, tcode, addr, length, frame, frame_size, error);
+}
 
 /**
  * hinawa_fw_req_transaction_async:
@@ -296,6 +325,7 @@ static gboolean initiate_transaction(HinawaFwReq *self, HinawaFwNode *node, Hina
  * as long as event dispatcher runs.
  *
  * Since: 2.1.
+ * Deprecated: 2.6: Use [method@FwReq.request] instead.
  */
 void hinawa_fw_req_transaction_async(HinawaFwReq *self, HinawaFwNode *node,
 				     HinawaFwTcode tcode, guint64 addr, gsize length,

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -63,10 +63,10 @@ void hinawa_fw_req_transaction_sync(HinawaFwReq *self, HinawaFwNode *node,
 			       guint8 *const *frame, gsize *frame_size, guint timeout_ms,
 			       GError **error);
 
-gboolean hinawa_fw_req_transaction_with_tstamp_sync(HinawaFwReq *self, HinawaFwNode *node,
-				HinawaFwTcode tcode, guint64 addr, gsize length,
-				guint8 **frame, gsize *frame_size, guint tstamp[2],
-				guint timeout_ms, GError **error);
+gboolean hinawa_fw_req_transaction_with_tstamp(HinawaFwReq *self, HinawaFwNode *node,
+					       HinawaFwTcode tcode, guint64 addr, gsize length,
+					       guint8 **frame, gsize *frame_size, guint tstamp[2],
+					       guint timeout_ms, GError **error);
 
 void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 			       HinawaFwTcode tcode, guint64 addr, gsize length,

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -53,6 +53,10 @@ struct _HinawaFwReqClass {
 
 HinawaFwReq *hinawa_fw_req_new(void);
 
+gboolean hinawa_fw_req_request(HinawaFwReq *self, HinawaFwNode *node, HinawaFwTcode tcode,
+			       guint64 addr, gsize length, guint8 *const *frame, gsize *frame_size,
+			       GError **error);
+
 void hinawa_fw_req_transaction_async(HinawaFwReq *self, HinawaFwNode *node,
 				     HinawaFwTcode tcode, guint64 addr, gsize length,
 				     guint8 *const *frame, gsize *frame_size,

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -172,7 +172,7 @@ HINAWA_2_6_0 {
 
     "hinawa_fw_node_read_cycle_time";
 
-    "hinawa_fw_req_transaction_with_tstamp_sync";
+    "hinawa_fw_req_transaction_with_tstamp";
 
     "hinawa_fw_fcp_command_with_tstamp";
     "hinawa_fw_fcp_avc_transaction_with_tstamp";

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -172,6 +172,7 @@ HINAWA_2_6_0 {
 
     "hinawa_fw_node_read_cycle_time";
 
+    "hinawa_fw_req_request";
     "hinawa_fw_req_transaction_with_tstamp";
 
     "hinawa_fw_fcp_command_with_tstamp";

--- a/tests/fw-req
+++ b/tests/fw-req
@@ -18,6 +18,7 @@ methods = (
     'transaction',
     'transaction_async',
     'transaction_sync',
+    'request',
     'transaction_with_tstamp',
 )
 vmethods = (

--- a/tests/fw-req
+++ b/tests/fw-req
@@ -18,7 +18,7 @@ methods = (
     'transaction',
     'transaction_async',
     'transaction_sync',
-    'transaction_with_tstamp_sync',
+    'transaction_with_tstamp',
 )
 vmethods = (
     'do_responded',


### PR DESCRIPTION
As issued in #89 , in the convention of GNOME project, the keywords, `sync` and `async`, are used to distinguish asynchronous I/O. I misunderstood and misuse them for blocking/non-blocking API in `Hinawa.FwReq`.

This commit adds an alternative function to deprecate the previous methods. `Hinawa.FwReq.request()` is newly added to obsolete `Hinawa.FwReq.transaction_async()`. `Hinawa.FwReq.transaction_with_tstamp_sync()` is renamed to `Hinawa.FwReq.transaction_with_tstamp()` and obsoletes `Hinawa.FwReq.transaction_sync()`.

As a result, user space application is encouraged to use `Hinawa.FwReq.transaction_with_tstamp()`, `Hinawa.FwReq.request()`.

```
Takashi Sakamoto (2):
  fw_req: remove 'sync' suffix from
    Hinawa.FwReq.transaction_with_tstamp()
  fw_req: add Hinawa.FwReq.request() to obsolete usage of 'async'

 README.rst                 | 10 +++++++--
 samples/common/__init__.py |  2 +-
 src/fw_fcp.c               | 10 ++++-----
 src/fw_req.c               | 45 ++++++++++++++++++++++++++++++++------
 src/fw_req.h               | 12 ++++++----
 src/hinawa.map             |  3 ++-
 tests/fw-req               |  3 ++-
 7 files changed, 64 insertions(+), 21 deletions(-)
```