### PR TITLE
[PATCH 0/10] change signatures of functions with GLib.Error

### DIFF
--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -57,7 +57,7 @@ def print_fw_node_information(node: Hinawa.FwNode):
     print_generation_information(node)
 
     print('  Config ROM:')
-    image = node.get_config_rom()
+    _, image = node.get_config_rom()
     quads = unpack('>{}I'.format(len(image) // 4), image)
     for i, q in enumerate(quads):
         print('    0xfffff00004{:02x}: 0x{:08x}'.format(i * 4, q))

--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -111,7 +111,7 @@ def read_quadlet(node: Hinawa.FwNode, req: Hinawa.FwReq, addr: int) -> int:
 @contextmanager
 def run_dispatcher(node: Hinawa.FwNode):
     ctx = GLib.MainContext.new()
-    src = node.create_source()
+    _, src = node.create_source()
     src.attach(ctx)
 
     dispatcher = GLib.MainLoop.new(ctx, False)

--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -195,7 +195,7 @@ def listen_fcp(node: Hinawa.FwNode):
     fcp = Hinawa.FwFcp()
     handler = fcp.connect('responded2', handle_responded2, (node, cycle_time))
     try:
-        fcp.bind(node)
+        _ = fcp.bind(node)
 
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
         initiate_cycle = cycle_time.get_fields()[:2]

--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -164,7 +164,7 @@ def listen_region(node: Hinawa.FwNode):
     cycle_time = Hinawa.CycleTime.new()
     handler = resp.connect('requested3', handle_requested3, (node, cycle_time))
     try:
-        resp.reserve(node, 0xfffff0000d00, 0x100)
+        _ = resp.reserve(node, 0xfffff0000d00, 0x100)
         yield
     except Exception as e:
         print(e)

--- a/samples/gtk3
+++ b/samples/gtk3
@@ -27,7 +27,7 @@ def main() -> int:
 
     try:
         node = Hinawa.FwNode.new()
-        node.open(str(path))
+        _ = node.open(str(path), 0)
         common.print_fw_node_information(node)
     except Exception as e:
         msg = str(e)

--- a/samples/gtk4
+++ b/samples/gtk4
@@ -27,7 +27,7 @@ def main() -> int:
 
     try:
         node = Hinawa.FwNode.new()
-        node.open(str(path))
+        _ = node.open(str(path), 0)
         common.print_fw_node_information(node)
     except Exception as e:
         msg = str(e)

--- a/samples/qt5
+++ b/samples/qt5
@@ -39,7 +39,7 @@ def main() -> int:
 
     try:
         node = Hinawa.FwNode.new()
-        node.open(str(path))
+        _ = node.open(str(path), 0)
         common.print_fw_node_information(node)
     except Exception as e:
         msg = str(e)

--- a/src/cycle_time.h
+++ b/src/cycle_time.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __HINAWA_CYCLE_TIME_H__
-#define __HINAWA_CYCLE_TIME_H__
+#ifndef __ORG_KERNEL_HINAWA_CYCLE_TIME_H__
+#define __ORG_KERNEL_HINAWA_CYCLE_TIME_H__
 
 #include <hinawa.h>
 

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -586,26 +586,28 @@ static HinawaFwRcode handle_requested3_signal(HinawaFwResp *resp, HinawaFwTcode 
  *
  * Start to listen to FCP responses.
  *
- * Since: 1.4
+ * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
+ *
+ * Since: 3.0
  */
-void hinawa_fw_fcp_bind(HinawaFwFcp *self, HinawaFwNode *node, GError **error)
+gboolean hinawa_fw_fcp_bind(HinawaFwFcp *self, HinawaFwNode *node, GError **error)
 {
 	HinawaFwFcpPrivate *priv;
 
-	g_return_if_fail(HINAWA_IS_FW_FCP(self));
-	g_return_if_fail(node != NULL);
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINAWA_IS_FW_FCP(self), FALSE);
+	g_return_val_if_fail(node != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinawa_fw_fcp_get_instance_private(self);
 
 	if (priv->node == NULL) {
-		hinawa_fw_resp_reserve(HINAWA_FW_RESP(self), node,
-				FCP_RESPOND_ADDR, FCP_MAXIMUM_FRAME_BYTES,
-				error);
-		if (*error != NULL)
-			return;
+		if (!hinawa_fw_resp_reserve(HINAWA_FW_RESP(self), node, FCP_RESPOND_ADDR,
+					    FCP_MAXIMUM_FRAME_BYTES, error))
+			return FALSE;
 		priv->node = g_object_ref(node);
 	}
+
+	return TRUE;
 }
 
 /**

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -458,18 +458,19 @@ end:
  * the case that AV/C INTERIM status is arrived, thus the caller should expand the timeout in
  * advance for the case.
  *
- * Since: 2.1.
- * Deprecated: 2.6: Use [method@FwFcp.avc_transaction_with_tstamp], instead.
+ * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
+ *
+ * Since: 3.0.
  */
-void hinawa_fw_fcp_avc_transaction(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
-				   guint8 *const *resp, gsize *resp_size, guint timeout_ms,
-				   GError **error)
+gboolean hinawa_fw_fcp_avc_transaction(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
+				       guint8 **resp, gsize *resp_size, guint timeout_ms,
+				       GError **error)
 {
 	struct waiter w;
 	guint tstamp[3];
 
-	(void)complete_avc_transaction(self, cmd, cmd_size, resp, resp_size, timeout_ms, &w,
-				       tstamp, error);
+	return complete_avc_transaction(self, cmd, cmd_size, resp, resp_size, timeout_ms, &w,
+					tstamp, error);
 }
 
 /**

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -286,19 +286,20 @@ static gboolean complete_command_transaction(HinawaFwFcp *self, const guint8 *cm
  * @error: A [struct@GLib.Error]. Error can be generated with four domains; Hinoko.FwNodeError and
  *	   Hinoko.FwReqError.
  *
- * Transfer command frame for FCP. When receiving response frame for FCP, [signal@FwFcp::responded]
+ * Transfer command frame for FCP. When receiving response frame for FCP, [signal@FwFcp::responded2]
  * signal is emitted.
  *
- * Since: 2.1.
- * Deprecated: 2.6: Use [method@FwFcp.command_with_tstamp], instead.
+ * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
+ *
+ * Since: 3.0.
  */
-void hinawa_fw_fcp_command(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
-			   guint timeout_ms, GError **error)
+gboolean hinawa_fw_fcp_command(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
+			       guint timeout_ms, GError **error)
 {
 	guint tstamp[2];
 
 	// Finish transaction for command frame.
-	(void)complete_command_transaction(self, cmd, cmd_size, tstamp, timeout_ms, error);
+	return complete_command_transaction(self, cmd, cmd_size, tstamp, timeout_ms, error);
 }
 
 /**
@@ -314,7 +315,7 @@ void hinawa_fw_fcp_command(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
  * @error: A [struct@GLib.Error]. Error can be generated with four domains; Hinoko.FwNodeError and
  *	   Hinoko.FwReqError.
  *
- * Transfer command frame for FCP. When receiving response frame for FCP, [signal@FwFcp::responded]
+ * Transfer command frame for FCP. When receiving response frame for FCP, [signal@FwFcp::responded2]
  * signal is emitted.
  *
  * Each value of @tstamp is unsigned 16 bit integer including higher 3 bits for three low order bits

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __ALSA_HINAWA_FW_FCP_H__
-#define __ALSA_HINAWA_FW_FCP_H__
+#ifndef __ORG_KERNEL_HINAWA_FW_FCP_H__
+#define __ORG_KERNEL_HINAWA_FW_FCP_H__
 
 #include <hinawa.h>
 

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -56,8 +56,8 @@ void hinawa_fw_fcp_transaction(HinawaFwFcp *self,
 gboolean hinawa_fw_fcp_bind(HinawaFwFcp *self, HinawaFwNode *node, GError **error);
 void hinawa_fw_fcp_unbind(HinawaFwFcp *self);
 
-void hinawa_fw_fcp_command(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
-			   guint timeout_ms, GError **error);
+gboolean hinawa_fw_fcp_command(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
+			       guint timeout_ms, GError **error);
 gboolean hinawa_fw_fcp_command_with_tstamp(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
 					   guint tstamp[2], guint timeout_ms, GError **error);
 

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -53,7 +53,7 @@ void hinawa_fw_fcp_transaction(HinawaFwFcp *self,
 			       guint8 *const *resp_frame, gsize *resp_frame_size,
 			       GError **error);
 
-void hinawa_fw_fcp_bind(HinawaFwFcp *self, HinawaFwNode *node, GError **error);
+gboolean hinawa_fw_fcp_bind(HinawaFwFcp *self, HinawaFwNode *node, GError **error);
 void hinawa_fw_fcp_unbind(HinawaFwFcp *self);
 
 void hinawa_fw_fcp_command(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -61,9 +61,9 @@ gboolean hinawa_fw_fcp_command(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_s
 gboolean hinawa_fw_fcp_command_with_tstamp(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
 					   guint tstamp[2], guint timeout_ms, GError **error);
 
-void hinawa_fw_fcp_avc_transaction(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
-				   guint8 *const *resp, gsize *resp_size, guint timeout_ms,
-				   GError **error);
+gboolean hinawa_fw_fcp_avc_transaction(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
+				       guint8 **resp, gsize *resp_size, guint timeout_ms,
+				       GError **error);
 gboolean hinawa_fw_fcp_avc_transaction_with_tstamp(HinawaFwFcp *self, const guint8 *cmd,
 					gsize cmd_size, guint8 **resp, gsize *resp_size,
 					guint tstamp[3], guint timeout_ms, GError **error);

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -400,23 +400,24 @@ gboolean hinawa_fw_node_open(HinawaFwNode *self, const gchar *path, gint open_fl
  *
  * Get cached content of configuration ROM aligned to big-endian.
  *
- * Since: 1.4.
+ * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
+ *
+ * Since: 3.0.
  */
-void hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
-				   gsize *length, GError **error)
+gboolean hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image, gsize *length,
+				       GError **error)
 {
 	HinawaFwNodePrivate *priv;
 
-	g_return_if_fail(HINAWA_IS_FW_NODE(self));
-	g_return_if_fail(image != NULL);
-	g_return_if_fail(length != NULL);
-	g_return_if_fail(error == NULL || *error == NULL);
-
+	g_return_val_if_fail(HINAWA_IS_FW_NODE(self), FALSE);
+	g_return_val_if_fail(image != NULL, FALSE);
+	g_return_val_if_fail(length != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinawa_fw_node_get_instance_private(self);
 	if (priv->fd < 0) {
 		generate_local_error(error, HINAWA_FW_NODE_ERROR_NOT_OPENED);
-		return;
+		return FALSE;
 	}
 
 	g_mutex_lock(&priv->mutex);
@@ -425,6 +426,8 @@ void hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
 	*length = priv->config_rom_length;
 
 	g_mutex_unlock(&priv->mutex);
+
+	return TRUE;
 }
 
 /**

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -579,10 +579,11 @@ static void finalize_src(GSource *gsrc)
  * Create [struct@GLib.Source] for [struct@GLib.MainContext] to dispatch events for the node on
  * IEEE 1394 bus.
  *
- * Since: 1.4.
+ * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
+ *
+ * Since: 3.0.
  */
-void hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc,
-				  GError **error)
+gboolean hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc, GError **error)
 {
         static GSourceFuncs funcs = {
                 .check          = check_src,
@@ -592,14 +593,14 @@ void hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc,
 	HinawaFwNodePrivate *priv;
 	FwNodeSource *src;
 
-	g_return_if_fail(HINAWA_IS_FW_NODE(self));
-	g_return_if_fail(gsrc != NULL);
-	g_return_if_fail(error == NULL || *error == NULL);
+	g_return_val_if_fail(HINAWA_IS_FW_NODE(self), FALSE);
+	g_return_val_if_fail(gsrc != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
 	priv = hinawa_fw_node_get_instance_private(self);
 	if (priv->fd < 0) {
 		generate_local_error(error, HINAWA_FW_NODE_ERROR_NOT_OPENED);
-		return;
+		return FALSE;
 	}
 
         *gsrc = g_source_new(&funcs, sizeof(FwNodeSource));
@@ -614,6 +615,8 @@ void hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc,
 
 	src->self = self;
 	src->tag = g_source_add_unix_fd(*gsrc, priv->fd, G_IO_IN);
+
+	return TRUE;
 }
 
 // Internal use only.

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -49,8 +49,7 @@ gboolean hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
 gboolean hinawa_fw_node_read_cycle_time(HinawaFwNode *self, gint clock_id,
 					HinawaCycleTime *const *cycle_time, GError **error);
 
-void hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc,
-				  GError **error);
+gboolean hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc, GError **error);
 
 G_END_DECLS
 

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __ALSA_HINAWA_FW_NODE_H__
-#define __ALSA_HINAWA_FW_NODE_H__
+#ifndef __ORG_KERNEL_HINAWA_FW_NODE_H__
+#define __ORG_KERNEL_HINAWA_FW_NODE_H__
 
 #include <hinawa.h>
 

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -41,8 +41,7 @@ struct _HinawaFwNodeClass {
 
 HinawaFwNode *hinawa_fw_node_new(void);
 
-void hinawa_fw_node_open(HinawaFwNode *self, const gchar *path,
-			 GError **error);
+gboolean hinawa_fw_node_open(HinawaFwNode *self, const gchar *path, gint open_flag, GError **error);
 
 void hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
 				   gsize *length, GError **error);

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -43,8 +43,8 @@ HinawaFwNode *hinawa_fw_node_new(void);
 
 gboolean hinawa_fw_node_open(HinawaFwNode *self, const gchar *path, gint open_flag, GError **error);
 
-void hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
-				   gsize *length, GError **error);
+gboolean hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image, gsize *length,
+				       GError **error);
 
 gboolean hinawa_fw_node_read_cycle_time(HinawaFwNode *self, gint clock_id,
 					HinawaCycleTime *const *cycle_time, GError **error);

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -546,28 +546,27 @@ gboolean hinawa_fw_req_transaction_with_tstamp(HinawaFwReq *self, HinawaFwNode *
  *	   transaction.
  * @frame_size: The size of array in byte unit. The value of this argument should point to the
  *		numerical number and mutable for read and lock transaction.
+ * @timeout_ms: The timeout to wait for response subaction of the transaction since request
+ *		subaction is initiated, in milliseconds.
  * @error: A [struct@GLib.Error]. Error can be generated with two domains; Hinawa.FwNodeError and
  *	   Hinawa.FwReqError.
  *
  * Execute request subaction of transaction to the given node according to given code, then wait
  * for response subaction within the value of timeout argument.
  *
- * Since: 1.4
- * Deprecated: 2.1: Use [method@FwReq.transaction_with_tstamp()] instead.
+ * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
+ *
+ * Since: 3.0
  */
-void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
+gboolean hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
 			       HinawaFwTcode tcode, guint64 addr, gsize length,
-			       guint8 *const *frame, gsize *frame_size,
+			       guint8 **frame, gsize *frame_size, guint timeout_ms,
 			       GError **error)
 {
-	HinawaFwReqPrivate *priv;
 	struct waiter w;
 
-	g_return_if_fail(HINAWA_IS_FW_REQ(self));
-	priv = hinawa_fw_req_get_instance_private(self);
-
-	(void)complete_transaction(self, node, tcode, addr, length, frame, frame_size,
-				   priv->timeout, &w, error);
+	return complete_transaction(self, node, tcode, addr, length, frame, frame_size, timeout_ms,
+				    &w, error);
 }
 
 // NOTE: For HinawaFwNode, internal.

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __ALSA_HINAWA_FW_REQ_H__
-#define __ALSA_HINAWA_FW_REQ_H__
+#ifndef __ORG_KERNEL_HINAWA_FW_REQ_H__
+#define __ORG_KERNEL_HINAWA_FW_REQ_H__
 
 #include <hinawa.h>
 

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -72,10 +72,10 @@ gboolean hinawa_fw_req_transaction_with_tstamp(HinawaFwReq *self, HinawaFwNode *
 					       guint8 **frame, gsize *frame_size, guint tstamp[2],
 					       guint timeout_ms, GError **error);
 
-void hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
-			       HinawaFwTcode tcode, guint64 addr, gsize length,
-			       guint8 *const *frame, gsize *frame_size,
-			       GError **error);
+gboolean hinawa_fw_req_transaction(HinawaFwReq *self, HinawaFwNode *node,
+				   HinawaFwTcode tcode, guint64 addr, gsize length,
+				   guint8 **frame, gsize *frame_size, guint timeout_ms,
+				   GError **error);
 
 G_END_DECLS
 

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -363,12 +363,14 @@ gboolean hinawa_fw_resp_reserve_within_region(HinawaFwResp *self, HinawaFwNode *
  * is a variant of [method@FwResp.reserve_within_region] so that the exact range of address should
  * be reserved as given.
  *
- * Since: 1.4.
+ * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
+ *
+ * Since: 3.0.
  */
-void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode *node,
-			    guint64 addr, guint width, GError **error)
+gboolean hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode *node, guint64 addr, guint width,
+				GError **error)
 {
-	(void)hinawa_fw_resp_reserve_within_region(self, node, addr, addr + width, width, error);
+	return hinawa_fw_resp_reserve_within_region(self, node, addr, addr + width, width, error);
 }
 
 /**

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -84,9 +84,9 @@ struct _HinawaFwRespClass {
 
 HinawaFwResp *hinawa_fw_resp_new(void);
 
-void hinawa_fw_resp_reserve_within_region(HinawaFwResp *self, HinawaFwNode *node,
-					  guint64 region_start, guint64 region_end, guint width,
-					  GError **error);
+gboolean hinawa_fw_resp_reserve_within_region(HinawaFwResp *self, HinawaFwNode *node,
+					      guint64 region_start, guint64 region_end,
+					      guint width, GError **error);
 void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
 			    guint64 addr, guint width, GError **error);
 void hinawa_fw_resp_release(HinawaFwResp *self);

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -87,8 +87,8 @@ HinawaFwResp *hinawa_fw_resp_new(void);
 gboolean hinawa_fw_resp_reserve_within_region(HinawaFwResp *self, HinawaFwNode *node,
 					      guint64 region_start, guint64 region_end,
 					      guint width, GError **error);
-void hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node,
-			    guint64 addr, guint width, GError **error);
+gboolean hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode*node, guint64 addr, guint width,
+				GError **error);
 void hinawa_fw_resp_release(HinawaFwResp *self);
 
 void hinawa_fw_resp_get_req_frame(HinawaFwResp *self, const guint8 **frame,

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __ALSA_HINAWA_FW_RESP_H__
-#define __ALSA_HINAWA_FW_RESP_H__
+#ifndef __ORG_KERNEL_HINAWA_FW_RESP_H__
+#define __ORG_KERNEL_HINAWA_FW_RESP_H__
 
 #include <hinawa.h>
 

--- a/src/hinawa.h
+++ b/src/hinawa.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __ALSA_HINAWA_H__
-#define __ALSA_HINAWA_H__
+#ifndef __ORG_KERNEL_HINAWA_H__
+#define __ORG_KERNEL_HINAWA_H__
 
 #include <glib.h>
 #include <glib-object.h>

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -48,8 +48,6 @@ HINAWA_2_0_0 {
 
     "hinawa_fw_resp_get_req_frame";
     "hinawa_fw_resp_set_resp_frame";
-
-    "hinawa_fw_req_transaction";
 } HINAWA_1_4_0;
 
 HINAWA_2_1_0 {
@@ -112,4 +110,6 @@ HINAWA_3_0_0 {
     "hinawa_fw_node_open";
     "hinawa_fw_node_get_config_rom";
     "hinawa_fw_node_create_source";
+
+    "hinawa_fw_req_transaction";
 } HINAWA_2_6_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -35,7 +35,6 @@ HINAWA_1_3_0 {
 HINAWA_1_4_0 {
     "hinawa_fw_node_get_type";
     "hinawa_fw_node_new";
-    "hinawa_fw_node_open";
     "hinawa_fw_node_create_source";
 
     "hinawa_fw_resp_reserve";
@@ -110,3 +109,8 @@ HINAWA_2_6_0 {
     "hinawa_fw_fcp_command_with_tstamp";
     "hinawa_fw_fcp_avc_transaction_with_tstamp";
 } HINAWA_2_5_0;
+
+HINAWA_3_0_0 {
+  global:
+    "hinawa_fw_node_open";
+} HINAWA_2_6_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -60,7 +60,6 @@ HINAWA_2_1_0 {
     "hinawa_fw_req_transaction_async";
     "hinawa_fw_req_transaction_sync";
 
-    "hinawa_fw_fcp_command";
     "hinawa_fw_fcp_avc_transaction";
 } HINAWA_2_0_0;
 
@@ -113,4 +112,5 @@ HINAWA_3_0_0 {
     "hinawa_fw_resp_reserve";
 
     "hinawa_fw_fcp_bind";
+    "hinawa_fw_fcp_command";
 } HINAWA_2_6_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -35,7 +35,6 @@ HINAWA_1_3_0 {
 HINAWA_1_4_0 {
     "hinawa_fw_node_get_type";
     "hinawa_fw_node_new";
-    "hinawa_fw_node_create_source";
 
     "hinawa_fw_resp_reserve";
     "hinawa_fw_resp_release";
@@ -112,4 +111,5 @@ HINAWA_3_0_0 {
   global:
     "hinawa_fw_node_open";
     "hinawa_fw_node_get_config_rom";
+    "hinawa_fw_node_create_source";
 } HINAWA_2_6_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -59,8 +59,6 @@ HINAWA_2_1_0 {
 
     "hinawa_fw_req_transaction_async";
     "hinawa_fw_req_transaction_sync";
-
-    "hinawa_fw_fcp_avc_transaction";
 } HINAWA_2_0_0;
 
 HINAWA_2_2_0 {
@@ -113,4 +111,5 @@ HINAWA_3_0_0 {
 
     "hinawa_fw_fcp_bind";
     "hinawa_fw_fcp_command";
+    "hinawa_fw_fcp_avc_transaction";
 } HINAWA_2_6_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -36,7 +36,6 @@ HINAWA_1_4_0 {
     "hinawa_fw_node_get_type";
     "hinawa_fw_node_new";
 
-    "hinawa_fw_resp_reserve";
     "hinawa_fw_resp_release";
 
     "hinawa_fw_fcp_bind";
@@ -112,4 +111,5 @@ HINAWA_3_0_0 {
     "hinawa_fw_req_transaction";
 
     "hinawa_fw_resp_reserve_within_region";
+    "hinawa_fw_resp_reserve";
 } HINAWA_2_6_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -45,8 +45,6 @@ HINAWA_1_4_0 {
 } HINAWA_1_3_0;
 
 HINAWA_2_0_0 {
-    "hinawa_fw_node_get_config_rom";
-
     "hinawa_fw_fcp_transaction";
 
     "hinawa_fw_resp_get_req_frame";
@@ -113,4 +111,5 @@ HINAWA_2_6_0 {
 HINAWA_3_0_0 {
   global:
     "hinawa_fw_node_open";
+    "hinawa_fw_node_get_config_rom";
 } HINAWA_2_6_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -73,8 +73,6 @@ HINAWA_2_2_0 {
 } HINAWA_2_1_0;
 
 HINAWA_2_3_0 {
-  global:
-    "hinawa_fw_resp_reserve_within_region";
 } HINAWA_2_2_0;
 
 HINAWA_2_4_0 {
@@ -112,4 +110,6 @@ HINAWA_3_0_0 {
     "hinawa_fw_node_create_source";
 
     "hinawa_fw_req_transaction";
+
+    "hinawa_fw_resp_reserve_within_region";
 } HINAWA_2_6_0;

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -38,7 +38,6 @@ HINAWA_1_4_0 {
 
     "hinawa_fw_resp_release";
 
-    "hinawa_fw_fcp_bind";
     "hinawa_fw_fcp_unbind";
 } HINAWA_1_3_0;
 
@@ -112,4 +111,6 @@ HINAWA_3_0_0 {
 
     "hinawa_fw_resp_reserve_within_region";
     "hinawa_fw_resp_reserve";
+
+    "hinawa_fw_fcp_bind";
 } HINAWA_2_6_0;

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __ALSA_HINAWA_ENUM_TYPES_H__
-#define __ALSA_HINAWA_ENUM_TYPES_H__
+#ifndef __ORG_KERNEL_HINAWA_ENUM_TYPES_H__
+#define __ORG_KERNEL_HINAWA_ENUM_TYPES_H__
 
 G_BEGIN_DECLS
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-#ifndef __ALSA_HINAWA_INTERNAL_H__
-#define __ALSA_HINAWA_INTERNAL_H__
+#ifndef __ORG_KERNEL_HINAWA_INTERNAL_H__
+#define __ORG_KERNEL_HINAWA_INTERNAL_H__
 
 #include "hinawa.h"
 


### PR DESCRIPTION
In GLib convention, the function with GLib.Error should return gboolean to report error.

* https://docs.gtk.org/glib/error-reporting.html

Some functions still returns void even if they have an argument for GLib.Error.

This series fixes the issue, filed at #91 .

```
Takashi Sakamoto (10):
  rename include guards with ORG_KERNEL prefix instead of ALSA prefix
  fw_node: change signature of FwNode.open()
  fw_node: change signature of FwNode.get_config_rom()
  fw_node: change signature of FwNode.create_source()
  fw_req: change signature of FwReq.transaction()
  fw_resp: change signature of FwResp.reserve_within_region()
  fw_resp: change signature of FwResp.reserve()
  fw_fcp: change signature of FwFcp.bind()
  fw_fcp: change signature of FwFcp.command()
  fw_fcp: change signature of FwFcp.avc_transaction()

 samples/common/__init__.py |  8 ++---
 samples/gtk3               |  2 +-
 samples/gtk4               |  2 +-
 samples/qt5                |  2 +-
 src/cycle_time.h           |  4 +--
 src/fw_fcp.c               | 52 ++++++++++++++++---------------
 src/fw_fcp.h               | 16 +++++-----
 src/fw_node.c              | 63 +++++++++++++++++++++++---------------
 src/fw_node.h              | 14 ++++-----
 src/fw_req.c               | 19 ++++++------
 src/fw_req.h               | 12 ++++----
 src/fw_resp.c              | 34 +++++++++++---------
 src/fw_resp.h              | 14 ++++-----
 src/hinawa.h               |  4 +--
 src/hinawa.map             | 29 ++++++++++--------
 src/hinawa_enum_types.h    |  4 +--
 src/internal.h             |  4 +--
 17 files changed, 153 insertions(+), 130 deletions(-)
```