### PR TITLE
[PATCH 0/6] rename signals

### DIFF
--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -141,11 +141,11 @@ def print_frame(frame: list):
         print('  [{:02d}]: 0x{:02x}'.format(i, frame[i]))
 
 
-def handle_requested3(resp: Hinawa.FwResp, tcode: Hinawa.FwRcode, offset: int,
-                      src: int, dst: int, card: int, generation: int, tstamp: int,
-                      frame: list, length: int, args: tuple[Hinawa.FwNode, Hinawa.CycleTime]):
+def handle_requested(resp: Hinawa.FwResp, tcode: Hinawa.FwRcode, offset: int,
+                     src: int, dst: int, card: int, generation: int, tstamp: int,
+                     frame: list, length: int, args: tuple[Hinawa.FwNode, Hinawa.CycleTime]):
     node, cycle_time = args
-    print('Event requested3: {0}'.format(tcode.value_nick))
+    print('Event requested: {0}'.format(tcode.value_nick))
     try:
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
         isoc_cycle = cycle_time.compute_tstamp(tstamp)
@@ -162,7 +162,7 @@ def handle_requested3(resp: Hinawa.FwResp, tcode: Hinawa.FwRcode, offset: int,
 def listen_region(node: Hinawa.FwNode):
     resp = Hinawa.FwResp()
     cycle_time = Hinawa.CycleTime.new()
-    handler = resp.connect('requested3', handle_requested3, (node, cycle_time))
+    handler = resp.connect('requested', handle_requested, (node, cycle_time))
     try:
         _ = resp.reserve(node, 0xfffff0000d00, 0x100)
         yield

--- a/samples/common/__init__.py
+++ b/samples/common/__init__.py
@@ -173,10 +173,10 @@ def listen_region(node: Hinawa.FwNode):
     resp.release()
 
 
-def handle_responded2(fcp: Hinawa.FwFcp, tstamp: int, frame: list, length: int,
-                      args: tuple[Hinawa.FwNode, Hinawa.CycleTime]):
+def handle_responded(fcp: Hinawa.FwFcp, tstamp: int, frame: list, length: int,
+                     args: tuple[Hinawa.FwNode, Hinawa.CycleTime]):
     node, cycle_time = args
-    print('Event responded2: length {}'.format(length))
+    print('Event responded: length {}'.format(length))
     try:
         _, cycle_time = node.read_cycle_time(CLOCK_MONOTONIC_RAW, cycle_time)
         isoc_cycle = cycle_time.compute_tstamp(tstamp)
@@ -193,7 +193,7 @@ def listen_fcp(node: Hinawa.FwNode):
     cycle_time = Hinawa.CycleTime.new()
 
     fcp = Hinawa.FwFcp()
-    handler = fcp.connect('responded2', handle_responded2, (node, cycle_time))
+    handler = fcp.connect('responded', handle_responded, (node, cycle_time))
     try:
         _ = fcp.bind(node)
 

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -107,15 +107,15 @@ enum fw_fcp_sig_type {
 static guint fw_fcp_sigs[FW_FCP_SIG_TYPE_COUNT] = { 0 };
 
 // Define later.
-static HinawaFwRcode handle_requested3_signal(HinawaFwResp *resp, HinawaFwTcode tcode, guint64 offset,
-					      guint src, guint dst, guint card, guint generation,
-					      guint tstamp, const guint8 *frame, guint length);
+static HinawaFwRcode handle_requested_signal(HinawaFwResp *resp, HinawaFwTcode tcode, guint64 offset,
+					     guint src, guint dst, guint card, guint generation,
+					     guint tstamp, const guint8 *frame, guint length);
 
 static void hinawa_fw_fcp_class_init(HinawaFwFcpClass *klass)
 {
 	GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
 
-	HINAWA_FW_RESP_CLASS(klass)->requested3 = handle_requested3_signal;
+	HINAWA_FW_RESP_CLASS(klass)->requested = handle_requested_signal;
 
 	gobject_class->get_property = fw_fcp_get_property;
 	gobject_class->finalize = fw_fcp_finalize;
@@ -424,18 +424,18 @@ end:
  * Since: 3.0
  */
 gboolean hinawa_fw_fcp_avc_transaction(HinawaFwFcp *self, const guint8 *cmd, gsize cmd_size,
-				       guint8 **resp, gsize *resp_size, guint timeout_ms,
-				       GError **error)
+                                      guint8 **resp, gsize *resp_size, guint timeout_ms,
+                                      GError **error)
 {
-	guint tstamp[3];
+       guint tstamp[3];
 
-	return hinawa_fw_fcp_avc_transaction_with_tstamp(self, cmd, cmd_size, resp, resp_size,
-							 tstamp, timeout_ms, error);
+       return hinawa_fw_fcp_avc_transaction_with_tstamp(self, cmd, cmd_size, resp, resp_size,
+                                                        tstamp, timeout_ms, error);
 }
 
-static HinawaFwRcode handle_requested3_signal(HinawaFwResp *resp, HinawaFwTcode tcode, guint64 offset,
-					      guint src, guint dst, guint card, guint generation,
-					      guint tstamp, const guint8 *frame, guint length)
+static HinawaFwRcode handle_requested_signal(HinawaFwResp *resp, HinawaFwTcode tcode, guint64 offset,
+					     guint src, guint dst, guint card, guint generation,
+					     guint tstamp, const guint8 *frame, guint length)
 {
 	HinawaFwFcp *self = HINAWA_FW_FCP(resp);
 	HinawaFwFcpPrivate *priv = hinawa_fw_fcp_get_instance_private(self);

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -18,7 +18,7 @@ struct _HinawaFwFcpClass {
 	HinawaFwRespClass parent_class;
 
 	/**
-	 * HinawaFwFcpClass::responded2:
+	 * HinawaFwFcpClass::responded:
 	 * @self: A [class@FwFcp].
 	 * @tstamp: The time stamp at which the request arrived for the response for FCP
 	 *	    transaction.
@@ -26,11 +26,11 @@ struct _HinawaFwFcpClass {
 	 *	   data of response for Function Control Protocol.
 	 * @frame_size: The number of elements of the array.
 	 *
-	 * Class closure for the [signal@FwFcp::responded2] signal.
+	 * Class closure for the [signal@FwFcp::responded] signal.
 	 *
-	 * Since: 2.6
+	 * Since: 3.0
 	 */
-	void (*responded2)(HinawaFwFcp *self, guint tstamp, const guint8 *frame, guint frame_size);
+	void (*responded)(HinawaFwFcp *self, guint tstamp, const guint8 *frame, guint frame_size);
 };
 
 HinawaFwFcp *hinawa_fw_fcp_new(void);

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -442,10 +442,10 @@ gboolean hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *
- * Since: 2.6
+ * Since: 3.0
  */
 gboolean hinawa_fw_node_read_cycle_time(HinawaFwNode *self, gint clock_id,
-					HinawaCycleTime *const *cycle_time, GError **error)
+					HinawaCycleTime **cycle_time, GError **error)
 {
 	int err;
 

--- a/src/fw_node.h
+++ b/src/fw_node.h
@@ -47,7 +47,7 @@ gboolean hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
 				       GError **error);
 
 gboolean hinawa_fw_node_read_cycle_time(HinawaFwNode *self, gint clock_id,
-					HinawaCycleTime *const *cycle_time, GError **error);
+					HinawaCycleTime **cycle_time, GError **error);
 
 gboolean hinawa_fw_node_create_source(HinawaFwNode *self, GSource **gsrc, GError **error);
 

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -135,10 +135,10 @@ HinawaFwReq *hinawa_fw_req_new(void)
  * response subaction arrives and running event dispatcher reads the contents,
  * [signal@FwReq::responded] signal handler is called.
  *
- * Since: 2.6
+ * Since: 3.0
  */
 gboolean hinawa_fw_req_request(HinawaFwReq *self, HinawaFwNode *node, HinawaFwTcode tcode,
-			       guint64 addr, gsize length, guint8 *const *frame, gsize *frame_size,
+			       guint64 addr, gsize length, guint8 **frame, gsize *frame_size,
 			       GError **error)
 {
 	struct fw_cdev_send_request req = {0};

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -18,7 +18,7 @@ struct _HinawaFwReqClass {
 	GObjectClass parent_class;
 
 	/**
-	 * HinawaFwReqClass::responded2:
+	 * HinawaFwReqClass::responded:
 	 * @self: A [class@FwReq].
 	 * @rcode: One of [enum@FwRcode].
 	 * @request_tstamp: The isochronous cycle at which the request was sent.
@@ -27,12 +27,12 @@ struct _HinawaFwReqClass {
 	 *	   byte data of response subaction for transaction.
 	 * @frame_size: The number of elements of the array.
 	 *
-	 * Class closure for the [signal@FwReq::responded2] signal.
+	 * Class closure for the [signal@FwReq::responded] signal.
 	 *
-	 * Since: 2.6
+	 * Since: 3.0
 	 */
-	void (*responded2)(HinawaFwReq *self, HinawaFwRcode rcode, guint request_tstamp,
-			   guint response_tstamp, const guint8 *frame, guint frame_size);
+	void (*responded)(HinawaFwReq *self, HinawaFwRcode rcode, guint request_tstamp,
+			  guint response_tstamp, const guint8 *frame, guint frame_size);
 };
 
 HinawaFwReq *hinawa_fw_req_new(void);

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -38,7 +38,7 @@ struct _HinawaFwReqClass {
 HinawaFwReq *hinawa_fw_req_new(void);
 
 gboolean hinawa_fw_req_request(HinawaFwReq *self, HinawaFwNode *node, HinawaFwTcode tcode,
-			       guint64 addr, gsize length, guint8 *const *frame, gsize *frame_size,
+			       guint64 addr, gsize length, guint8 **frame, gsize *frame_size,
 			       GError **error);
 
 gboolean hinawa_fw_req_transaction_with_tstamp(HinawaFwReq *self, HinawaFwNode *node,

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -64,7 +64,7 @@ static GParamSpec *fw_resp_props[FW_RESP_PROP_TYPE_COUNT] = { NULL, };
 
 // This object has one signal.
 enum fw_resp_sig_type {
-	FW_RESP_SIG_TYPE_REQ3 = 0,
+	FW_RESP_SIG_TYPE_REQ = 0,
 	FW_RESP_SIG_TYPE_COUNT,
 };
 static guint fw_resp_sigs[FW_RESP_SIG_TYPE_COUNT] = { 0 };
@@ -154,7 +154,7 @@ static void hinawa_fw_resp_class_init(HinawaFwRespClass *klass)
 					  fw_resp_props);
 
 	/**
-	 * HinawaFwResp::requested3:
+	 * HinawaFwResp::requested:
 	 * @self: A [class@FwResp]
 	 * @tcode: One of [enum@FwTcode] enumerations
 	 * @offset: The address offset at which the transaction arrives.
@@ -183,13 +183,13 @@ static void hinawa_fw_resp_class_init(HinawaFwRespClass *klass)
 	 *
 	 * Returns: One of [enum@FwRcode] enumerations corresponding to rcodes defined in IEEE 1394
 	 *	    specification.
-	 * Since: 2.6
+	 * Since: 3.0
 	 */
-	fw_resp_sigs[FW_RESP_SIG_TYPE_REQ3] =
-		g_signal_new("requested3",
+	fw_resp_sigs[FW_RESP_SIG_TYPE_REQ] =
+		g_signal_new("requested",
 			     G_OBJECT_CLASS_TYPE(klass),
 			     G_SIGNAL_RUN_LAST,
-			     G_STRUCT_OFFSET(HinawaFwRespClass, requested3),
+			     G_STRUCT_OFFSET(HinawaFwRespClass, requested),
 			     NULL, NULL,
 			     hinawa_sigs_marshal_ENUM__ENUM_UINT64_UINT_UINT_UINT_UINT_UINT_POINTER_UINT,
 			     HINAWA_TYPE_FW_RCODE, 9, HINAWA_TYPE_FW_TCODE, G_TYPE_UINT64,
@@ -387,7 +387,7 @@ void hinawa_fw_resp_handle_request(HinawaFwResp *self, const struct fw_cdev_even
 	if (!priv->node || event->length > priv->width) {
 		rcode = RCODE_CONFLICT_ERROR;
 	} else {
-		g_signal_emit(self, fw_resp_sigs[FW_RESP_SIG_TYPE_REQ3], 0, event->tcode,
+		g_signal_emit(self, fw_resp_sigs[FW_RESP_SIG_TYPE_REQ], 0, event->tcode,
 			      event->offset, G_MAXUINT, G_MAXUINT, G_MAXUINT, G_MAXUINT,
 			      G_MAXUINT, event->data, event->length, &rcode);
 	}
@@ -423,7 +423,7 @@ void hinawa_fw_resp_handle_request2(HinawaFwResp *self, const struct fw_cdev_eve
 	} else {
 		rcode = HINAWA_FW_RCODE_ADDRESS_ERROR;
 
-		g_signal_emit(self, fw_resp_sigs[FW_RESP_SIG_TYPE_REQ3], 0, event->tcode,
+		g_signal_emit(self, fw_resp_sigs[FW_RESP_SIG_TYPE_REQ], 0, event->tcode,
 			      event->offset, event->source_node_id, event->destination_node_id,
 			      event->card, event->generation, G_MAXUINT, event->data, event->length,
 			      &rcode);
@@ -460,7 +460,7 @@ void hinawa_fw_resp_handle_request3(HinawaFwResp *self, const struct fw_cdev_eve
 	} else {
 		rcode = HINAWA_FW_RCODE_ADDRESS_ERROR;
 
-		g_signal_emit(self, fw_resp_sigs[FW_RESP_SIG_TYPE_REQ3], 0, event->tcode,
+		g_signal_emit(self, fw_resp_sigs[FW_RESP_SIG_TYPE_REQ], 0, event->tcode,
 			      event->offset, event->source_node_id, event->destination_node_id,
 			      event->card, event->generation, event->tstamp, event->data,
 			      event->length, &rcode);

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -18,7 +18,7 @@ struct _HinawaFwRespClass {
 	GObjectClass parent_class;
 
 	/**
-	 * HinawaFwRespClass::requested3:
+	 * HinawaFwRespClass::requested:
 	 * @self: A [class@FwResp]
 	 * @tcode: One of [enum@FwTcode] enumerations
 	 * @offset: The address offset at which the transaction arrives.
@@ -31,16 +31,16 @@ struct _HinawaFwRespClass {
 	 *	   data.
 	 * @length: The length of bytes for the frame.
 	 *
-	 * Class closure for the [signal@FwResp::requested3] signal.
+	 * Class closure for the [signal@FwResp::requested] signal.
 	 *
 	 * Returns: One of [enum@FwRcode enumerations corresponding to rcodes defined in IEEE 1394
 	 *	    specification.
 	 *
-	 * Since: 2.6
+	 * Since: 3.0
 	 */
-	HinawaFwRcode (*requested3)(HinawaFwResp *self, HinawaFwTcode tcode, guint64 offset,
-				    guint src, guint dst, guint card, guint generation,
-				    guint tstamp, const guint8 *frame, guint length);
+	HinawaFwRcode (*requested)(HinawaFwResp *self, HinawaFwTcode tcode, guint64 offset,
+				   guint src, guint dst, guint card, guint generation,
+				   guint tstamp, const guint8 *frame, guint length);
 };
 
 HinawaFwResp *hinawa_fw_resp_new(void);

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -19,8 +19,6 @@ HINAWA_1_0_0 {
   global:
     "hinawa_fw_tcode_get_type";
     "hinawa_fw_rcode_get_type";
-
-    "hinawa_sigs_marshal_ENUM__ENUM";
 } HINAWA_0_8_0;
 
 HINAWA_1_1_0 {

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -83,8 +83,6 @@ HINAWA_2_6_0 {
     "hinawa_cycle_time_compute_tstamp";
     "hinawa_cycle_time_parse_tstamp";
 
-    "hinawa_fw_node_read_cycle_time";
-
     "hinawa_fw_req_transaction_with_tstamp";
 
     "hinawa_fw_fcp_command_with_tstamp";
@@ -96,6 +94,7 @@ HINAWA_3_0_0 {
     "hinawa_fw_node_open";
     "hinawa_fw_node_get_config_rom";
     "hinawa_fw_node_create_source";
+    "hinawa_fw_node_read_cycle_time";
 
     "hinawa_fw_req_request";
     "hinawa_fw_req_transaction";

--- a/src/hinawa.map
+++ b/src/hinawa.map
@@ -85,7 +85,6 @@ HINAWA_2_6_0 {
 
     "hinawa_fw_node_read_cycle_time";
 
-    "hinawa_fw_req_request";
     "hinawa_fw_req_transaction_with_tstamp";
 
     "hinawa_fw_fcp_command_with_tstamp";
@@ -98,6 +97,7 @@ HINAWA_3_0_0 {
     "hinawa_fw_node_get_config_rom";
     "hinawa_fw_node_create_source";
 
+    "hinawa_fw_req_request";
     "hinawa_fw_req_transaction";
 
     "hinawa_fw_resp_reserve_within_region";

--- a/tests/fw-fcp
+++ b/tests/fw-fcp
@@ -23,10 +23,10 @@ methods = (
     'avc_transaction_with_tstamp',
 )
 vmethods = (
-    'do_responded2',
+    'do_responded',
 )
 signals = (
-    'responded2',
+    'responded',
 )
 
 if not test_object(target_type, props, methods, vmethods, signals):

--- a/tests/fw-req
+++ b/tests/fw-req
@@ -18,10 +18,10 @@ methods = (
     'transaction_with_tstamp',
 )
 vmethods = (
-    'do_responded2',
+    'do_responded',
 )
 signals = (
-    'responded2',
+    'responded',
 )
 
 if not test_object(target_type, props, methods, vmethods, signals):

--- a/tests/fw-resp
+++ b/tests/fw-resp
@@ -23,10 +23,10 @@ methods = (
     'release',
 )
 vmethods = (
-    'do_requested3',
+    'do_requested',
 )
 signals = (
-    'requested3',
+    'requested',
 )
 
 if not test_object(target_type, props, methods, vmethods, signals):


### PR DESCRIPTION
Now each object class has a sole signal, while the name of signal still includes the numeric suffix.

The series removes the suffix. Additionally, removes useless `*const` from prototypes of some functions.

```
Takashi Sakamoto (6):
  fw_req: remove numeric suffix from signal
  fw_resp: remove numeric suffix from signal
  fw_fcp: remove numeric suffix from signal
  fw_req: change prototype of FwReq.request()
  fw_node: change prototype of FwNode.read_cycle_time()
  remove unused global symbol

 samples/common/__init__.py | 18 +++++++-------
 src/fw_fcp.c               | 48 +++++++++++++++++++-------------------
 src/fw_fcp.h               |  8 +++----
 src/fw_node.c              |  4 ++--
 src/fw_node.h              |  2 +-
 src/fw_req.c               | 30 ++++++++++++------------
 src/fw_req.h               | 12 +++++-----
 src/fw_resp.c              | 18 +++++++-------
 src/fw_resp.h              | 12 +++++-----
 src/hinawa.map             |  7 ++----
 tests/fw-fcp               |  4 ++--
 tests/fw-req               |  4 ++--
 tests/fw-resp              |  4 ++--
 13 files changed, 84 insertions(+), 87 deletions(-)
```