### PR TITLE
fw_fcp: abort transaction at bus reset

### DIFF
--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -366,25 +366,25 @@ deferred:
 			break;
 	}
 
-	if (w.frame[0] == 0xff) {
-		generate_local_error(error, HINAWA_FW_FCP_ERROR_TIMEOUT);
-	} else if (w.frame[0] == AVC_STATUS_INTERIM) {
-		// It's a deffered transaction, wait again.
+	// It's a deffered transaction, wait again.
+	if (w.frame[0] == AVC_STATUS_INTERIM) {
 		w.frame[0] = 0x00;
 		w.frame_size = *resp_size;
 		// Although the timeout is infinite in 1394 TA specification,
 		// use the finite value for safe.
 		goto deferred;
-	} else if (w.frame_size > *resp_size) {
-		generate_local_error(error, HINAWA_FW_FCP_ERROR_LARGE_RESP);
-	} else {
-		*resp_size = w.frame_size;
 	}
 
-	if (*error != NULL)
+	if (w.frame[0] == 0xff) {
+		generate_local_error(error, HINAWA_FW_FCP_ERROR_TIMEOUT);
 		result = FALSE;
-	else
+	} else if (w.frame_size > *resp_size) {
+		generate_local_error(error, HINAWA_FW_FCP_ERROR_LARGE_RESP);
+		result = FALSE;
+	} else {
+		*resp_size = w.frame_size;
 		tstamp[2] = w.tstamp;
+	}
 end:
 	g_signal_handler_disconnect(self, handler_id);
 

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -153,6 +153,7 @@ typedef enum {
  * HinawaFwFcpError:
  * @HINAWA_FW_FCP_ERROR_TIMEOUT:	The transaction is canceled due to response timeout.
  * @HINAWA_FW_FCP_ERROR_LARGE_RESP:	The size of response is larger than expected.
+ * @HINAWA_FW_FCP_ERROR_ABORTED:	The transaction is aborted due to bus reset.
  *
  * A set of error code for [struct@GLib.Error] with domain which equals to Hinawa.FwFcpError.
  *
@@ -161,6 +162,7 @@ typedef enum {
 typedef enum {
 	HINAWA_FW_FCP_ERROR_TIMEOUT,
 	HINAWA_FW_FCP_ERROR_LARGE_RESP,
+	HINAWA_FW_FCP_ERROR_ABORTED,
 } HinawaFwFcpError;
 
 G_END_DECLS

--- a/tests/hinawa-enum
+++ b/tests/hinawa-enum
@@ -72,6 +72,7 @@ fw_resp_error_enumerations = (
 fw_fcp_error_enumerators = (
     'TIMEOUT',
     'LARGE_RESP',
+    'ABORTED',
 )
 
 types = {


### PR DESCRIPTION
In AV/C Digital interface Command Set General Specification, any transactions are going
to be aborted at bus reset.
    
The series is the support for the behaviour, including code refactoring.

```
Takashi Sakamoto (6):
  fw_fcp: code refactoring to check result of transaction
  fw_fcp: code refactoring for lifetime of handler and lock
  fw_fcp: maintain transaction in doubly-linked list
  fw_fcp: iterate list entries for transactions
  fw_fcp: use enumeration for state of transaction
  fw_fcp: abort transaction at bus reset

 src/fw_fcp.c            | 140 +++++++++++++++++++++++++++++++---------
 src/hinawa_enum_types.h |   2 +
 tests/hinawa-enum       |   1 +
 3 files changed, 113 insertions(+), 30 deletions(-)
```