### PR TITLE
[PATCH 0/2] fw_node/fw_fcp: support numeric index of 1394 OHCI hardware

### DIFF
--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -519,11 +519,11 @@ static HinawaFwRcode handle_requested_signal(HinawaFwResp *resp, HinawaFwTcode t
 {
 	HinawaFwFcp *self = HINAWA_FW_FCP(resp);
 	HinawaFwFcpPrivate *priv = hinawa_fw_fcp_get_instance_private(self);
-	guint node_id;
+	guint local_card_id;
 
-	g_object_get(priv->node, "node-id", &node_id, NULL);
+	g_object_get(priv->node, "card-id", &local_card_id, NULL);
 	if (offset == FCP_RESPOND_ADDR && tcode == HINAWA_FW_TCODE_WRITE_BLOCK_REQUEST &&
-	    src_node_id == node_id)
+	    card_id == local_card_id)
 		g_signal_emit(self, fw_fcp_sigs[FW_FCP_SIG_TYPE_RESPONDED], 0, tstamp, frame, length);
 
 	// MEMO: Linux firewire subsystem already send response subaction to finish the transaction,

--- a/tests/fw-node
+++ b/tests/fw-node
@@ -17,6 +17,7 @@ props = (
     'ir-manager-node-id',
     'root-node-id',
     'generation',
+    'card-id',
 )
 methods = (
     'new',


### PR DESCRIPTION
When multiple 1394 OHCI hardware are available, Linux FireWire subsystemmaintains them by numeric index. The instance of node device has a property about the numeric index and it is available in fw_cdev_get_info structure.

The numeric index is passed to an argument for Hinawa.FwResp::requested signal, thus it is convenient for user space application to retrieve the numeric index via property of Hinawa.FwNode.

The value of card_id is stable even if crossing bus reset, thus it is convenient for filtering request subaction.

This patchset introduces the property for numeric index.

```
Takashi Sakamoto (2):
  fw_node: add card_id property for the numeric ID of 1394 OHCI hardware
  fw_fcp: check card_id in requested event for transaction response

 src/fw_fcp.c  |  6 +++---
 src/fw_node.c | 22 ++++++++++++++++++++++
 tests/fw-node |  1 +
 3 files changed, 26 insertions(+), 3 deletions(-)
```