### PR TITLE
[PATCH 0/3] meson: declaration cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Dependencies
 Requirements to build
 =====================
 
-- Meson 0.56.0 or later
+- Meson 0.60.0 or later
 - Ninja
 - PyGObject (optional to run unit tests)
 - gi-docgen (optional to generate API documentation)

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 The libhinawa project
 =====================
 
-2023/10/01
+2023/10/07
 Takashi Sakamoto
 
 Instruction
@@ -50,7 +50,7 @@ Dependencies
 Requirements to build
 =====================
 
-- Meson 0.46.0 or later
+- Meson 0.54.0 or later
 - Ninja
 - PyGObject (optional to run unit tests)
 - gi-docgen (optional to generate API documentation)

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Dependencies
 Requirements to build
 =====================
 
-- Meson 0.54.0 or later
+- Meson 0.56.0 or later
 - Ninja
 - PyGObject (optional to run unit tests)
 - gi-docgen (optional to generate API documentation)

--- a/meson.build
+++ b/meson.build
@@ -1,16 +1,16 @@
 project('libhinawa', 'c',
   version: '2.6.1',
   license: 'LGPL-2.1+',
-  meson_version: '>= 0.56.0',
+  meson_version: '>= 0.60.0',
 )
 
 # Detect support level in Linux sound subsystem.
 cc = meson.get_compiler('c')
 
-header_dirs = []
+backport_header_dir = []
 if not cc.has_header_symbol('include/linux/firewire-cdev.h', 'FW_CDEV_EVENT_REQUEST3')
   # Use backport header from Linux kernel v5.16 prepatch.
-  header_dirs += include_directories('include')
+  backport_header_dir += include_directories('include')
 endif
 
 # For g-i and documentation.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libhinawa', 'c',
   version: '2.6.1',
   license: 'LGPL-2.1+',
-  meson_version: '>= 0.54.0',
+  meson_version: '>= 0.56.0',
 )
 
 # Detect support level in Linux sound subsystem.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libhinawa', 'c',
   version: '2.6.1',
   license: 'LGPL-2.1+',
-  meson_version: '>= 0.46.0',
+  meson_version: '>= 0.54.0',
 )
 
 # Detect support level in Linux sound subsystem.

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,14 +51,12 @@ enums = gnome.mkenums_simple('hinawa_enums',
 mapfile = 'hinawa.map'
 vflag = '-Wl,--version-script,' + join_paths(meson.current_source_dir(), mapfile)
 
-header_dirs += include_directories('.')
-
 myself = library('hinawa',
   sources: sources + headers + privates + marshallers + enums,
   version: meson.project_version(),
   soversion: meson.project_version().split('.')[0],
   install: true,
-  include_directories: header_dirs,
+  include_directories: backport_header_dir + include_directories('.'),
   dependencies: dependencies,
   link_args : vflag,
   link_depends : mapfile,

--- a/src/meson.build
+++ b/src/meson.build
@@ -100,3 +100,4 @@ hinawa_dep = declare_dependency(
   sources: headers + marshallers + enums + hinawa_gir,
   include_directories: include_directories('.'),
 )
+meson.override_dependency('hinawa', hinawa_dep)

--- a/src/meson.build
+++ b/src/meson.build
@@ -90,9 +90,6 @@ hinawa_gir = gnome.generate_gir(myself,
   install: true,
 )
 
-# For test.
-builddir = meson.current_build_dir()
-
 # For wrap dependency system.
 hinawa_dep = declare_dependency(
   link_with: myself,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,6 +8,9 @@ tests = [
   'hinawa-functions',
 ]
 
+
+builddir = join_paths(meson.project_build_root(), 'src')
+
 envs = environment()
 envs.append('LD_LIBRARY_PATH', builddir, separator : ':')
 envs.append('GI_TYPELIB_PATH', builddir, separator : ':')


### PR DESCRIPTION
The recent version of meson build gained some useful features. This series follows to it.

```
Takashi Sakamoto (3):
  meson: bump minimal dependency version up to 0.54.0 for
    meson.override_dependency()
  meson: bump minimal dependency version up to 0.56.0 for
    meson.project_build_root()
  meson: bump minimal dependency version up to 0.60.0 for list.<plus>

 README.rst        | 4 ++--
 meson.build       | 6 +++---
 src/meson.build   | 8 ++------
 tests/meson.build | 3 +++
 4 files changed, 10 insertions(+), 11 deletions(-)
```