### PR TITLE
[PATCH 0/4] doc: improve documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,27 @@ jobs:
     container:
       image: fedora:rawhide
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v2
     - name: Prepare build environment.
       run: |
         dnf -y upgrade
         dnf -y install @development-tools
         dnf -y install meson gobject-introspection-devel systemd-devel
         dnf -y install gi-docgen python3-gobject
+    - name: Checkout repository.
+      uses: actions/checkout@v2
+    - name: Create gi-docgen.wrap in subproject directory
+      run: |
+        mkdir subprojects
+        cat > subprojects/gi-docgen.wrap << EOF
+        [wrap-git]
+        directory = gi-docgen
+        url = https://gitlab.gnome.org/GNOME/gi-docgen.git
+        revision = 2023.1
+        depth = 1
+        
+        [provide]
+        program_names = gi-docgen
+        EOF
     - name: Initialization for build.
       run: |
         meson --prefix=/tmp. -Ddoc=true -Dwarning_level=3 . build
@@ -41,8 +54,6 @@ jobs:
     container:
       image: ubuntu:latest
     steps:
-    - name: Checkout repository.
-      uses: actions/checkout@v3
     - name: Prepare build environment.
       run: |
         DEBIAN_FRONTEND=noninteractive apt-get update
@@ -50,6 +61,21 @@ jobs:
         DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential
         DEBIAN_FRONTEND=noninteractive apt-get install -y meson ninja-build libglib2.0-dev gobject-introspection libgirepository1.0-dev
         DEBIAN_FRONTEND=noninteractive apt-get install -y gi-docgen python3-gi
+    - name: Checkout repository.
+      uses: actions/checkout@v2
+    - name: Create gi-docgen.wrap in subproject directory
+      run: |
+        mkdir subprojects
+        cat > subprojects/gi-docgen.wrap << EOF
+        [wrap-git]
+        directory = gi-docgen
+        url = https://gitlab.gnome.org/GNOME/gi-docgen.git
+        revision = 2023.1
+        depth = 1
+        
+        [provide]
+        program_names = gi-docgen
+        EOF
     - name: Initialization for build.
       run: |
         meson --prefix=/tmp. -Ddoc=true -Dwarning_level=3 . build

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Requirements to build
 - Meson 0.60.0 or later
 - Ninja
 - PyGObject (optional to run unit tests)
-- gi-docgen (optional to generate API documentation)
+- gi-docgen 2023.1 or later (optional to generate API documentation)
 
 How to build
 ============

--- a/doc/hinawa.toml.in
+++ b/doc/hinawa.toml.in
@@ -1,6 +1,6 @@
 [library]
 version = "@VERSION@"
-description = "The library to operate OHCI 1394 hardware for asynchronous communication in IEEE 1394 bus"
+description = "The library to operate 1394 OHCI hardware for asynchronous communication in IEEE 1394 bus"
 authors = "Takashi Sakamoto"
 license = "LGPL-2.1-or-later"
 website_url = "https://alsa-project.github.io/gobject-introspection-docs/hinawa/"

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -13,7 +13,7 @@ doc_toml = configure_file(
 )
 
 dependency('gi-docgen',
-  version: '>= 2021.8',
+  version: '>= 2023.1',
   fallback: ['gi-docgen', 'dummy_dep'],
 )
 gidocgen = find_program('gi-docgen')

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,7 +1,7 @@
 Title: Overview
 
 This library gives some objects for abstraction to operate system resources in Linux FireWire
-subsystem. This library mainly supports operations for asynchronous communication to nodes on
+subsystem. This library mainly supports operations for asynchronous communication with nodes in
 IEEE 1394 bus.
 
 This library originally supported some model-specific operations for Audio and Music units on

--- a/src/cycle_time.c
+++ b/src/cycle_time.c
@@ -95,9 +95,9 @@ static guint ieee1394_cycle_time_to_offset(guint32 cycle_time)
  * hinawa_cycle_time_get_fields:
  * @self: A [struct@CycleTime].
  * @fields: (array fixed-size=3) (out caller-allocates): The value of cycle time register of 1394
- *	    OHCI, including three elements; second, cycle, and offset in its order.
+ *	    OHCI hardware, including three elements; second, cycle, and offset in its order.
  *
- * Get the value of cycle time in 1394 OHCI controller. The first element of array expresses the
+ * Get the value of cycle time in 1394 OHCI hardware. The first element of array expresses the
  * value of sec field, up to 127. The second element of array expresses the value of cycle field,
  * up to 7999. The third element of array expresses the value of offset field, up to 3071.
  *
@@ -115,7 +115,7 @@ void hinawa_cycle_time_get_fields(const HinawaCycleTime *self, guint16 fields[3]
  * @self: A [struct@CycleTime].
  * @raw: (out caller-allocates): The raw value for CYCLE_TIME register.
  *
- * Get the value of cycle time in 1394 OHCI controller.
+ * Get the value of cycle time in 1394 OHCI hardware.
  *
  * Since: 2.6
  */

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -23,7 +23,7 @@
 /**
  * hinawa_fw_fcp_error_quark:
  *
- * Return the [alias@GLib.Quark] for [struct@GLib.Error] which has code in Hinawa.FwFcpError.
+ * Return the [alias@GLib.Quark] for [struct@GLib.Error] which has code in [error@FwFcpError].
  *
  * Since: 2.1
  *
@@ -230,8 +230,8 @@ HinawaFwFcp *hinawa_fw_fcp_new(void)
  *	    The first element is for the isochronous cycle at which the request arrived. The second
  *	    element is for the isochronous cycle at which the response was sent.
  * @timeout_ms: The timeout to wait for response subaction of transaction for command frame.
- * @error: A [struct@GLib.Error]. Error can be generated with four domains; Hinoko.FwNodeError and
- *	   Hinoko.FwReqError.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domains; [error@FwNodeError] and
+ *	   [error@FwReqError].
  *
  * Transfer command frame for FCP. When receiving response frame for FCP, [signal@FwFcp::responded]
  * signal is emitted.
@@ -280,8 +280,8 @@ gboolean hinawa_fw_fcp_command_with_tstamp(HinawaFwFcp *self, const guint8 *cmd,
  *	 argument should point to the array and immutable.
  * @cmd_size: The size of array for request in byte unit.
  * @timeout_ms: The timeout to wait for response subaction of transaction for command frame.
- * @error: A [struct@GLib.Error]. Error can be generated with four domains; Hinoko.FwNodeError and
- *	   Hinoko.FwReqError.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domains; [error@FwNodeError] and
+ *	   [error@FwReqError].
  *
  * Transfer command frame for FCP. When receiving response frame for FCP, [signal@FwFcp::responded]
  * signal is emitted.
@@ -363,8 +363,8 @@ static void handle_responded_signal(HinawaFwFcp *self, guint generation, guint t
  *	    which the response arrived for the command of FCP transaction. The third element is for
  *	    the isochronous cycle at which the request was sent for the response of FCP transaction.
  * @timeout_ms: The timeout to wait for response transaction since command transactions finishes.
- * @error: A [struct@GLib.Error]. Error can be generated with four domains; Hinawa.FwNodeError,
- *	   Hinawa.FwReqError, and Hinawa.FwFcpError.
+ * @error: A [struct@GLib.Error]. Error can be generated with thtree domains; [error@FwNodeError],
+ *	   [error@FwReqError], and [error@FwFcpError].
  *
  * Finish the pair of asynchronous transaction for AV/C command and response. The @timeout_ms
  * parameter is used to wait for response transaction since the command transaction is initiated.
@@ -488,8 +488,8 @@ end:
  * @resp_size: The size of array for response in byte unit. The value of this argument should point to
  *	       the numerical number and mutable.
  * @timeout_ms: The timeout to wait for response transaction since command transactions finishes.
- * @error: A [struct@GLib.Error]. Error can be generated with four domains; Hinawa.FwNodeError,
- *	   Hinawa.FwReqError, and Hinawa.FwFcpError.
+ * @error: A [struct@GLib.Error]. Error can be generated with three domains; [error@FwNodeError],
+ *	   [error@FwReqError], and [error@FwFcpError].
  *
  * Finish the pair of asynchronous transaction for AV/C command and response. The @timeout_ms
  * parameter is used to wait for response transaction since the command transaction is initiated.
@@ -639,7 +639,7 @@ static HinawaFwRcode handle_requested_signal(HinawaFwResp *resp, HinawaFwTcode t
  * hinawa_fw_fcp_bind:
  * @self: A [class@FwFcp].
  * @node: A [class@FwNode].
- * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinawa.FwFcpError.
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of [error@FwFcpError].
  *
  * Start to listen to FCP responses.
  *

--- a/src/fw_fcp.c
+++ b/src/fw_fcp.c
@@ -10,12 +10,13 @@
  * HinawaFwFcp:
  * A FCP transaction executor to node in IEEE 1394 bus.
  *
- * A HinawaFwFcp supports Function Control Protocol (FCP) in IEC 61883-1, in which no way is defined
- * to match response against command by the contents of frames. In 'AV/C Digital Interface Command
- * Set General Specification Version 4.2' (Sep 1 2004, 1394TA), a pair of command and response is
- * loosely matched by the contents of frames.
+ * [class@FwFcp] supports Function Control Protocol (FCP) in IEC 61883-1. FCP transaction consists
+ * of a pair of asynchronous transactions for command and response, while the protocol has no
+ * mechanism to match them. In AV/C Digital Interface Command Set General Specification Version 4.2
+ * (Sep 1 2004, 1394TA), they are loosely matched by the content of their frames, and this class
+ * employs the way.
  *
- * Any of transaction frames should be aligned to 8bit (byte). This class is an application of
+ * Any of transaction frames should be aligned to 8 bit (1 byte). This class is an application of
  * [class@FwReq] / [class@FwResp].
  */
 
@@ -365,10 +366,10 @@ static void handle_responded_signal(HinawaFwFcp *self, guint generation, guint t
  * @error: A [struct@GLib.Error]. Error can be generated with four domains; Hinawa.FwNodeError,
  *	   Hinawa.FwReqError, and Hinawa.FwFcpError.
  *
- * Finish the pair of asynchronous transaction for AV/C command and response transactions. The
- * timeout_ms parameter is used to wait for response transaction since the command transaction is
- * initiated. The timeout is not expanded in the case that AV/C INTERIM status arrived, thus the
- * caller should expand the timeout in advance for the case.
+ * Finish the pair of asynchronous transaction for AV/C command and response. The @timeout_ms
+ * parameter is used to wait for response transaction since the command transaction is initiated.
+ * The timeout is not expanded in the case that AV/C INTERIM status arrived, thus the caller should
+ * expand the timeout in advance for the case.
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  * Since: 2.6
@@ -490,10 +491,10 @@ end:
  * @error: A [struct@GLib.Error]. Error can be generated with four domains; Hinawa.FwNodeError,
  *	   Hinawa.FwReqError, and Hinawa.FwFcpError.
  *
- * Finish the pair of asynchronous transaction for AV/C command and response transactions. The
- * timeout_ms parameter is used to wait for response transaction since the command transaction is
- * initiated The timeout is not expanded in the case that AV/C INTERIM status arrived, thus the
- * caller should expand the timeout in advance for the case.
+ * Finish the pair of asynchronous transaction for AV/C command and response. The @timeout_ms
+ * parameter is used to wait for response transaction since the command transaction is initiated.
+ * The timeout is not expanded in the case that AV/C INTERIM status arrived, thus the caller should
+ * expand the timeout in advance for the case.
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *

--- a/src/fw_fcp.h
+++ b/src/fw_fcp.h
@@ -21,10 +21,10 @@ struct _HinawaFwFcpClass {
 	 * HinawaFwFcpClass::responded:
 	 * @self: A [class@FwFcp].
 	 * @generation: The generation of bus topology.
-	 * @tstamp: The time stamp at which the request arrived for the response for FCP
+	 * @tstamp: The time stamp at which the request subaction arrived for the response of FCP
 	 *	    transaction.
 	 * @frame: (array length=frame_size)(element-type guint8): The array with elements for byte
-	 *	   data of response for Function Control Protocol.
+	 *	   data in the response of Function Control Protocol.
 	 * @frame_size: The number of elements of the array.
 	 *
 	 * Class closure for the [signal@FwFcp::responded] signal.

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -41,7 +41,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(HinawaFwNode, hinawa_fw_node, G_TYPE_OBJECT)
 /**
  * hinawa_fw_node_error_quark:
  *
- * Return the [alias@GLib.Quark] for [struct@GLib.Error] with Hinawa.FwNodeError domain.
+ * Return the [alias@GLib.Quark] for [struct@GLib.Error] with [error@FwNodeError] domain.
  *
  * Since: 2.1
  *
@@ -355,8 +355,8 @@ static int update_info(HinawaFwNode *self)
  * @self: A [class@FwNode]
  * @path: A path to Linux FireWire character device
  * @open_flag: The flag of `open(2)` system call. `O_RDONLY` is fulfilled internally.
- * @error: A [struct@GLib.Error]. Error can be generated with two domains; GLib.Error and
- *	   Hinawa.FwNodeError.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domains; [error@GLib.FileError]
+ *	   and [error@FwNodeError].
  *
  * Open Linux FireWire character device to operate node in IEEE 1394 bus.
  *
@@ -596,7 +596,7 @@ static void finalize_src(GSource *gsrc)
  * hinawa_fw_node_create_source:
  * @self: A [class@FwNode].
  * @gsrc: (out): A [struct@GLib.Source].
- * @error: A [struct@GLib.Error]. Error can be generated with domain of Hinawa.FwNodeError.
+ * @error: A [struct@GLib.Error]. Error can be generated with domain of [error@FwNodeError].
  *
  * Create [struct@GLib.Source] for [struct@GLib.MainContext] to dispatch events for the node on
  * IEEE 1394 bus.

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -172,7 +172,7 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 	 * HinawaFwNode:local-node-id:
 	 *
 	 * Node ID of node which application uses to communicate to node associated to instance of
-	 * object at current generation of bus topology. In general, it is for 1394 OHCI controller.
+	 * object at current generation of bus topology. In general, it is for 1394 OHCI hardware.
 	 *
 	 * Since: 1.4
 	 */
@@ -180,7 +180,7 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 		g_param_spec_uint("local-node-id", "local-node-id",
 				  "Node ID of node which application uses to communicate to node "
 				  "associated to instance of object at current generation of bus "
-				  "topology. In general, it is for OHCI 1394 host controller.",
+				  "topology. In general, it is for 1394 OHCI hardware.",
 				  0, G_MAXUINT32, 0,
 				  G_PARAM_READABLE);
 
@@ -460,7 +460,7 @@ gboolean hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
  * @cycle_time: (inout): A [struct@CycleTime].
  * @error: A [struct@GLib.Error].
  *
- * Read current value of CYCLE_TIME register in 1394 OHCI controller.
+ * Read current value of CYCLE_TIME register in 1394 OHCI hardware.
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *

--- a/src/fw_node.c
+++ b/src/fw_node.c
@@ -10,11 +10,10 @@
 
 /**
  * HinawaFwNode:
- * An event listener for FireWire node
+ * An event listener for node in IEEE 1394 bus.
  *
- * A [class@FwNode] is an event listener for a specified node on IEEE 1394 bus. This class is an
- * application of Linux FireWire subsystem. All of operations utilize ioctl(2) with subsystem
- * specific request commands.
+ * [class@FwNode] listens to any events for an associated node in IEEE 1394 bus. Additionally,
+ * it provides some methods to retrieve fundamental information about the bus.
  *
  * Since: 1.4
  */
@@ -216,7 +215,7 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 	/**
 	 * HinawaFwNode:root-node-id:
 	 *
-	 * Node ID of root node in bus topology at current generation of the bus topology.
+	 * Node ID of root node in bus topology at current generation of bus topology.
 	 *
 	 * Since: 1.4
 	 */
@@ -243,7 +242,7 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 	/**
 	 * HinawaFwNode:card-id:
 	 *
-	 * The numeric index for 1394 OHCI hardware used for the communication to the node. The
+	 * The numeric index for 1394 OHCI hardware used for the communication with the node. The
 	 * value is stable against bus generation.
 	 *
 	 * Since: 3.0
@@ -251,7 +250,7 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 	fw_node_props[FW_NODE_PROP_TYPE_CARD_ID] =
 		g_param_spec_uint("card-id", "card-id",
 				  "The numeric index for 1394 OHCI hardware used for the "
-				  "communication to the node",
+				  "communication with the node",
 				  0, G_MAXUINT32, 0,
 				  G_PARAM_READABLE);
 
@@ -281,8 +280,8 @@ static void hinawa_fw_node_class_init(HinawaFwNodeClass *klass)
 	 * HinawaFwNode::disconnected:
 	 * @self: A [class@FwNode].
 	 *
-	 * Emitted when the node is not available anymore due to removal from IEEE 1394 bus. It's
-	 * preferable to call [method@GObject.Object.unref] immediately to release file descriptor.
+	 * Emitted when the node is not available anymore in Linux system. It's preferable to call
+	 * [method@GObject.Object.unref] immediately to release file descriptor.
 	 *
 	 * Since: 1.4
 	 */
@@ -359,7 +358,7 @@ static int update_info(HinawaFwNode *self)
  * @error: A [struct@GLib.Error]. Error can be generated with two domains; GLib.Error and
  *	   Hinawa.FwNodeError.
  *
- * Open Linux FireWire character device to operate node on IEEE 1394 bus.
+ * Open Linux FireWire character device to operate node in IEEE 1394 bus.
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *
@@ -417,7 +416,7 @@ gboolean hinawa_fw_node_open(HinawaFwNode *self, const gchar *path, gint open_fl
  * hinawa_fw_node_get_config_rom:
  * @self: A [class@FwNode]
  * @image: (array length=length)(out)(transfer none): The content of configuration ROM.
- * @length: (out): The number of bytes consists of the configuration rom.
+ * @length: (out): The number of bytes consists of the configuration ROM.
  * @error: A [struct@GLib.Error].
  *
  * Get cached content of configuration ROM aligned to big-endian.
@@ -460,7 +459,8 @@ gboolean hinawa_fw_node_get_config_rom(HinawaFwNode *self, const guint8 **image,
  * @cycle_time: (inout): A [struct@CycleTime].
  * @error: A [struct@GLib.Error].
  *
- * Read current value of CYCLE_TIME register in 1394 OHCI hardware.
+ * Read current value of CYCLE_TIME register in 1394 OHCI hardware dedicated to communicate with
+ * the associated node in IEEE 1394 bus.
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -7,7 +7,7 @@
 
 /**
  * HinawaFwReq:
- * A transaction executor to a FireWire unit.
+ * A transaction executor to a node in IEEE 1394 bus.
  *
  * A HinawaFwReq supports some types of transactions in IEEE 1212. Mainly for read, write and lock
  * operations.
@@ -71,7 +71,7 @@ static void hinawa_fw_req_class_init(HinawaFwReqClass *klass)
 	 *	   byte data of response subaction for transaction.
 	 * @frame_size: The number of elements of the array.
 	 *
-	 * Emitted when the unit transfers asynchronous packet as response subaction for the
+	 * Emitted when the node transfers asynchronous packet as response subaction for the
 	 * transaction and the process successfully reads the content of packet from Linux firewire
 	 * subsystem.
 	 *
@@ -184,7 +184,7 @@ gboolean hinawa_fw_req_request(HinawaFwReq *self, HinawaFwNode *node, HinawaFwTc
 		g_return_val_if_reached(FALSE);
 	}
 
-	// Get unit properties.
+	// Get node property.
 	g_object_get(G_OBJECT(node), "generation", &generation, NULL);
 
 	// Setup a transaction structure.

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -9,11 +9,7 @@
  * HinawaFwReq:
  * A transaction executor to a node in IEEE 1394 bus.
  *
- * A HinawaFwReq supports some types of transactions in IEEE 1212. Mainly for read, write and lock
- * operations.
- *
- * This class is an application of Linux FireWire subsystem. All of operations utilize ioctl(2)
- * with subsystem specific request commands.
+ * [class@FwReq] supports all types of transactions defiend in IEEE 1212.
  */
 
 /**
@@ -65,10 +61,12 @@ static void hinawa_fw_req_class_init(HinawaFwReqClass *klass)
 	 * HinawaFwReq::responded:
 	 * @self: A [class@FwReq].
 	 * @rcode: One of [enum@FwRcode].
-	 * @request_tstamp: The isochronous cycle at which the request was sent.
-	 * @response_tstamp: The isochronous cycle at which the response arrived.
+	 * @request_tstamp: The isochronous cycle at which the request subaction was sent for the
+	 *		    transaction.
+	 * @response_tstamp: The isochronous cycle at which the response subaction arrived for the
+	 *		     transaction.
 	 * @frame: (array length=frame_size)(element-type guint8): The array with elements for
-	 *	   byte data of response subaction for transaction.
+	 *	   byte data of response subaction for the transaction.
 	 * @frame_size: The number of elements of the array.
 	 *
 	 * Emitted when the node transfers asynchronous packet as response subaction for the
@@ -127,11 +125,11 @@ HinawaFwReq *hinawa_fw_req_new(void)
  *	   to the array and immutable. The content of array is mutable for read and lock
  *	   transaction.
  * @frame_size: The size of array in byte unit. The value of this argument should point to the
- *		numerical number and mutable for read and lock transaction.
+ *		numeric number and mutable for read and lock transaction.
  * @error: A [struct@GLib.Error]. Error can be generated with two domains; Hinawa.FwNodeError and
  *	   Hinawa.FwReqError.
  *
- * Execute request subaction of transactions to the given node according to given code. When the
+ * Execute request subaction of transaction to the given node according to given code. When the
  * response subaction arrives and running event dispatcher reads the contents,
  * [signal@FwReq::responded] signal handler is called.
  *
@@ -252,9 +250,9 @@ static void handle_responded_signal(HinawaFwReq *self, HinawaFwRcode rcode, guin
  * @frame_size: The size of array in byte unit. The value of this argument should point to the
  *		numeric number and mutable for read and lock transaction.
  * @tstamp: (array fixed-size=2)(out caller-allocates): The array with two elements for time stamps.
- *	    The first element is for the isochronous cycle at which the request was sent. The second
- *	    element is for the isochronous cycle at which the response arrived.
- * @timeout_ms: The timeout to wait for response subaction of the transaction since request
+ *	    The first element is for the isochronous cycle at which the request subaction was sent.
+ *	    The second element is for the isochronous cycle at which the response subaction arrived.
+ * @timeout_ms: The timeout to wait for the response subaction of transaction since the request
  *		subaction is initiated, in milliseconds.
  * @error: A [struct@GLib.Error]. Error can be generated with two domains; Hinawa.FwNodeError and
  *	   Hinawa.FwReqError.

--- a/src/fw_req.c
+++ b/src/fw_req.c
@@ -126,8 +126,8 @@ HinawaFwReq *hinawa_fw_req_new(void)
  *	   transaction.
  * @frame_size: The size of array in byte unit. The value of this argument should point to the
  *		numeric number and mutable for read and lock transaction.
- * @error: A [struct@GLib.Error]. Error can be generated with two domains; Hinawa.FwNodeError and
- *	   Hinawa.FwReqError.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domains; [error@FwNodeError] and
+ *	   [error@FwReqError].
  *
  * Execute request subaction of transaction to the given node according to given code. When the
  * response subaction arrives and running event dispatcher reads the contents,
@@ -254,8 +254,8 @@ static void handle_responded_signal(HinawaFwReq *self, HinawaFwRcode rcode, guin
  *	    The second element is for the isochronous cycle at which the response subaction arrived.
  * @timeout_ms: The timeout to wait for the response subaction of transaction since the request
  *		subaction is initiated, in milliseconds.
- * @error: A [struct@GLib.Error]. Error can be generated with two domains; Hinawa.FwNodeError and
- *	   Hinawa.FwReqError.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domains; [error@FwNodeError] and
+ *	   [error@FwReqError].
  *
  * Execute request subaction of transaction to the given node according to given code, then wait
  * for response subaction within the given timeout.
@@ -362,8 +362,8 @@ gboolean hinawa_fw_req_transaction_with_tstamp(HinawaFwReq *self, HinawaFwNode *
  *		numerical number and mutable for read and lock transaction.
  * @timeout_ms: The timeout to wait for response subaction of the transaction since request
  *		subaction is initiated, in milliseconds.
- * @error: A [struct@GLib.Error]. Error can be generated with two domains; Hinawa.FwNodeError and
- *	   Hinawa.FwReqError.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domains; [error@FwNodeError] and
+ *	   [error@FwReqError].
  *
  * Execute request subaction of transaction to the given node according to given code, then wait
  * for response subaction within the value of timeout argument. The function is a thin wrapper to

--- a/src/fw_req.h
+++ b/src/fw_req.h
@@ -21,10 +21,12 @@ struct _HinawaFwReqClass {
 	 * HinawaFwReqClass::responded:
 	 * @self: A [class@FwReq].
 	 * @rcode: One of [enum@FwRcode].
-	 * @request_tstamp: The isochronous cycle at which the request was sent.
-	 * @response_tstamp: The isochronous cycle at which the response arrived.
-	 * @frame: (array length=frame_size)(element-type guint8): The array with elements for
-	 *	   byte data of response subaction for transaction.
+	 * @request_tstamp: The isochronous cycle at which the request subaction was sent for the
+	 *		    transaction.
+	 * @response_tstamp: The isochronous cycle at which the response subaction arrived for the
+	 *		     transaction.
+	 * @frame: (array length=frame_size)(element-type guint8): The array with elements for byte
+	 *	   data of the response subaction of transaction.
 	 * @frame_size: The number of elements of the array.
 	 *
 	 * Class closure for the [signal@FwReq::responded] signal.

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -16,7 +16,7 @@
  * hinawa_fw_resp_error_quark:
  *
  * Return the [alias@GLib.Quark] for error domain of [struct@GLib.Error] which has code in
- * Hinawa.FwRespError.
+ * [error@FwRespError].
  *
  * Since: 2.2
  *
@@ -219,8 +219,8 @@ HinawaFwResp *hinawa_fw_resp_new(void)
  * @region_start:  Start offset of address region in which range of address is looked up.
  * @region_end:  End offset of address region in which range of address is looked up.
  * @width: The width for range of address to be looked up.
- * @error: A [struct@GLib.Error]. Error can be generated with two domain of Hinawa.FwNodeError and
- *	   Hinawa.FwRespError.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domain of [error@FwNodeError] and
+ *	   [error@FwRespError].
  *
  * Allocate an address range within Linux system for local nodes, each of which expresses 1394
  * OHCI hardware. Once successful, [signal@FwResp::requested] signal will be emitted whenever any
@@ -286,8 +286,8 @@ gboolean hinawa_fw_resp_reserve_within_region(HinawaFwResp *self, HinawaFwNode *
  * @node: A [class@FwNode].
  * @addr: A start address to listen to in 1394 OHCI hardware.
  * @width: The byte width of address to listen to 1394 OHCI hardware.
- * @error: A [struct@GLib.Error]. Error can be generated with two domain of Hinawa.FwNodeError and
- *	   and Hinawa.FwRespError.
+ * @error: A [struct@GLib.Error]. Error can be generated with two domain of [error@FwNodeError] and
+ *	   and [error@FwRespError].
  *
  * Allocate an address range within Linux system for local nodes, each of which expresses 1394
  * OHCI hardware. Once successful, [signal@FwResp::requested] signal will be emitted whenever any

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -110,14 +110,13 @@ static void hinawa_fw_resp_class_init(HinawaFwRespClass *klass)
 	/**
 	 * HinawaFwResp:is-reserved:
 	 *
-	 * Whether a range of address is reserved or not in host controller.
+	 * Whether a range of address is reserved or not.
 	 *
 	 * Since: 2.0
 	 */
 	fw_resp_props[FW_RESP_PROP_TYPE_IS_RESERVED] =
 		g_param_spec_boolean("is-reserved", "is-reserved",
-				     "Whether a range of address is reserved "
-				     "or not in host controller. ",
+				     "Whether a range of address is reserved or not.",
 				     FALSE,
 				     G_PARAM_READABLE);
 
@@ -160,7 +159,7 @@ static void hinawa_fw_resp_class_init(HinawaFwRespClass *klass)
 	 * @offset: The address offset at which the transaction arrives.
 	 * @src_node_id: The node ID of source for the transaction.
 	 * @dst_node_id: The node ID of destination for the transaction.
-	 * @card_id: The index of card specific to the 1394 OHCI controller at which the request
+	 * @card_id: The index of card specific to the 1394 OHCI hardware at which the request
 	 *	     subaction arrived.
 	 * @generation: The generation of bus when the transaction is transferred.
 	 * @tstamp: The isochronous cycle at which the request arrived.
@@ -288,8 +287,8 @@ gboolean hinawa_fw_resp_reserve_within_region(HinawaFwResp *self, HinawaFwNode *
  * hinawa_fw_resp_reserve:
  * @self: A [class@FwResp].
  * @node: A [class@FwNode].
- * @addr: A start address to listen to in host controller.
- * @width: The byte width of address to listen to host controller.
+ * @addr: A start address to listen to in 1394 OHCI hardware.
+ * @width: The byte width of address to listen to 1394 OHCI hardware.
  * @error: A [struct@GLib.Error]. Error can be generated with two domain of Hinawa.FwNodeError and
  *	   and Hinawa.FwRespError.
  *

--- a/src/fw_resp.c
+++ b/src/fw_resp.c
@@ -9,10 +9,7 @@
  * HinawaFwResp:
  * A transaction responder for request subaction initiated by node in IEEE 1394 bus.
  *
- * The [class@FwResp] responds to request subaction initiated by node in IEEE 1394 bus.
- *
- * This class is an application of Linux FireWire subsystem. Some operations utilize ioctl(2)
- * with subsystem specific request commands.
+ * [class@FwResp] responds to request subaction initiated by node in IEEE 1394 bus.
  */
 
 /**
@@ -225,12 +222,12 @@ HinawaFwResp *hinawa_fw_resp_new(void)
  * @error: A [struct@GLib.Error]. Error can be generated with two domain of Hinawa.FwNodeError and
  *	   Hinawa.FwRespError.
  *
- * Allocate an address range within Linux system for local nodes, each of which represents 1394
+ * Allocate an address range within Linux system for local nodes, each of which expresses 1394
  * OHCI hardware. Once successful, [signal@FwResp::requested] signal will be emitted whenever any
  * request subactions arrive at the 1394 OHCI hardware within the dedicated range.
  *
  * The range is reserved between the values specified by @region_start and @region_end with the size
- * indicated by @width, The starting offset may vary every time.
+ * indicated by @width. The starting offset may vary every time.
  *
  * Returns: TRUE if the overall operation finishes successfully, otherwise FALSE.
  *
@@ -292,7 +289,7 @@ gboolean hinawa_fw_resp_reserve_within_region(HinawaFwResp *self, HinawaFwNode *
  * @error: A [struct@GLib.Error]. Error can be generated with two domain of Hinawa.FwNodeError and
  *	   and Hinawa.FwRespError.
  *
- * Allocate an address range within Linux system for local nodes, each of which represents 1394
+ * Allocate an address range within Linux system for local nodes, each of which expresses 1394
  * OHCI hardware. Once successful, [signal@FwResp::requested] signal will be emitted whenever any
  * request subactions arrive at the 1394 OHCI hardware within the dedicated range.
  *
@@ -314,7 +311,7 @@ gboolean hinawa_fw_resp_reserve(HinawaFwResp *self, HinawaFwNode *node, guint64 
  * hinawa_fw_resp_release:
  * @self: A [class@FwResp].
  *
- * Stop listening to the address range in Linu system for local nodes.
+ * Stop listening to the address range in Linux system for local nodes.
  *
  * Since: 1.4
  */
@@ -353,10 +350,10 @@ void hinawa_fw_resp_release(HinawaFwResp *self)
 /**
  * hinawa_fw_resp_set_resp_frame:
  * @self: A [class@FwResp]
- * @frame: (element-type guint8)(array length=length): a 8bit array for response frame.
+ * @frame: (element-type guint8)(array length=length): a 8 bit array for response frame.
  * @length: The length of bytes for the frame.
  *
- * Register byte frame for the response subaction.
+ * Register byte frame for the response subaction of transaction.
  *
  * Since: 2.0
  */

--- a/src/fw_resp.h
+++ b/src/fw_resp.h
@@ -24,7 +24,7 @@ struct _HinawaFwRespClass {
 	 * @offset: The address offset at which the transaction arrives.
 	 * @src_node_id: The node ID of source for the transaction.
 	 * @dst_node_id: The node ID of destination for the transaction.
-	 * @card_id: The index of card specific to 1394 OHCI controller at which the request
+	 * @card_id: The index of card specific to 1394 OHCI hardware at which the request
 	 *	     subaction arrived.
 	 * @generation: The generation of bus when the transaction is transferred.
 	 * @tstamp: The time stamp at which the request arrived.

--- a/src/hinawa_enum_types.h
+++ b/src/hinawa_enum_types.h
@@ -95,8 +95,8 @@ typedef enum {
  * @HINAWA_FW_REQ_ERROR_NO_ACK:		For no acknowledge.
  * @HINAWA_FW_REQ_ERROR_INVALID:	For rcode out of specification.
  *
- * A set of error code for [class@Hinawa.FwReq]. Each of them has the same value as the
- * corresponding enumeration in [enum@Hinawa.FwRcode].
+ * A set of error code for [struct@GLib.Error] for operations in [class@FwReq].
+ * The actual value is equivalent to [enum@FwRcode].
  *
  * Since: 2.5.
  */
@@ -122,7 +122,7 @@ typedef enum {
  *					firewire character device.
  * @HINAWA_FW_NODE_ERROR_FAILED:	The system call fails.
  *
- * A set of error code for [struct@GLib.Error] with domain which equals to Hinawa.FwNodeError.
+ * A set of error code for [struct@GLib.Error] for operations in [class@FwNode].
  *
  * Since: 2.1
  */
@@ -139,7 +139,7 @@ typedef enum {
  * @HINAWA_FW_RESP_ERROR_RESERVED:		The instance is already associated to reserved address range.
  * @HINAWA_FW_RESP_ERROR_ADDR_SPACE_USED:	The address space is used exclusively.
  *
- * A set of error code for [struct@GLib.Error] with domain which equals to Hinawa.FwRespError.
+ * A set of error code for [struct@GLib.Error] for operations in [class@FwResp].
  *
  * Since: 2.2
  */
@@ -155,7 +155,7 @@ typedef enum {
  * @HINAWA_FW_FCP_ERROR_LARGE_RESP:	The size of response is larger than expected.
  * @HINAWA_FW_FCP_ERROR_ABORTED:	The transaction is aborted due to bus reset.
  *
- * A set of error code for [struct@GLib.Error] with domain which equals to Hinawa.FwFcpError.
+ * A set of error code for [struct@GLib.Error] for operations in [class@FwFcp].
  *
  * Since: 2.1
  */

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,7 +68,7 @@ install_headers(headers,
 
 pkg = import('pkgconfig')
 pkg.generate(myself,
-  description: 'The library to operate OHCI 1394 hardware for asynchronous communication in IEEE 1394 bus',
+  description: 'The library to operate 1394 OHCI hardware for asynchronous communication in IEEE 1394 bus',
   subdirs: inc_dir,
 )
 


### PR DESCRIPTION
This patch series update documentation as a preparation for version 4.0 release

```
Takashi Sakamoto (4):
  doc: use the word '1394 OHCI hardware' for consistency
  doc: obsolete usage of word 'unit' with 'node'
  doc: update annotations for functions, properties, and signals
  doc: annotate error domain available in gi-docgen 2023.1

 .github/workflows/build.yml | 34 +++++++++++++++++++++++----
 README.rst                  |  2 +-
 doc/hinawa.toml.in          |  2 +-
 doc/meson.build             |  2 +-
 src/cycle_time.c            |  6 ++---
 src/fw_fcp.c                | 47 +++++++++++++++++++------------------
 src/fw_fcp.h                |  4 ++--
 src/fw_node.c               | 26 ++++++++++----------
 src/fw_req.c                | 42 ++++++++++++++++-----------------
 src/fw_req.h                | 10 ++++----
 src/fw_resp.c               | 38 ++++++++++++++----------------
 src/fw_resp.h               |  2 +-
 src/hinawa_enum_types.h     |  6 ++---
 src/meson.build             |  2 +-
 14 files changed, 123 insertions(+), 100 deletions(-)

-- 
2.39.2
```